### PR TITLE
Add seed_app support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /spec/error_screenshots/
 .idea
 /.powenv
+/db/seed_apps.yml

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ to contribute to TestTrack, and stay on the latest version of the open
 source product.
 
 You can use a configuration management tool like
-[`boxen`](https://github.com/boxen/our-boxen) to install TestTrack and
+[boxen](https://github.com/boxen/our-boxen) to install TestTrack and
 inject a custom `seed_apps.yml` file for your team.
 
 ### Creating Admins

--- a/README.md
+++ b/README.md
@@ -58,6 +58,35 @@ In order to create spilts in your client applications, you will need to register
 
 This is the password that you should plug into your client application's `TEST_TRACK_API_URL`.
 
+#### Seeding Apps For Local Development
+At Betterment, we run TestTrack in every environment, including our
+laptops, which enables engineers to override splits with the Chrome
+extension while they code.
+
+TestTrack provides a Rake task to make it easier to set up apps that
+automatically get reloaded whenever you recreate your TestTrack
+database. If you want to add a rails app called `widget_maker` to
+TestTrack, run:
+
+```shell
+rake seed_app[widget_maker]
+```
+
+This will do three things:
+* Find or create a file called `db/seed_apps.yml`
+* Find or create an entry in it for your app name and set a randomly
+  generated `auth_secret`
+* Run `rake db:seed`, which reloads your seed apps into the database
+
+Note that `db/seed_apps.yml` is `.gitignore`d so you can run TestTrack
+locally without having a private copy of the `test_track` repository or
+having uncommitted changes on your local checkout. That way it's easier
+to contribute to TestTrack, and stay on the latest version of the open
+source product.
+
+You can use a configuration management tool like `boxen` to install
+TestTrack and inject a custom `seed_apps.yml` file for your team.
+
 ### Creating Admins
 In order to access the admin features of the TestTrack server, you must create an `Admin` in your database. Run the following in a rails console.
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ having uncommitted changes on your local checkout. That way it's easier
 to contribute to TestTrack, and stay on the latest version of the open
 source product.
 
-You can use a configuration management tool like `boxen` to install
-TestTrack and inject a custom `seed_apps.yml` file for your team.
+You can use a configuration management tool like
+[`boxen`](https://github.com/boxen/our-boxen) to install TestTrack and
+inject a custom `seed_apps.yml` file for your team.
 
 ### Creating Admins
 In order to access the admin features of the TestTrack server, you must create an `Admin` in your database. Run the following in a rails console.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,11 @@
+# To generate a seed for an app called "widget_maker" run `rake seed_app[widget_maker]`
+
+if Rails.env.development?
+  seed_apps_filename = Rails.root.join('db/seed_apps.yml')
+  if File.exists?(seed_apps_filename)
+    YAML.load_file(seed_apps_filename).each do |app_name, auth_secret|
+      App.create_with(auth_secret: auth_secret).find_or_create_by!(name: app_name).update!(auth_secret: auth_secret)
+      puts "Ensured #{app_name} app"
+    end
+  end
+end

--- a/lib/tasks/seed_app.rake
+++ b/lib/tasks/seed_app.rake
@@ -7,7 +7,7 @@ task :seed_app, [:app_name] do |_, opts|
     next
   end
 
-  existing_apps = File.exists?(seed_app_filename) ? YAML.load_file(seed_app_filename) : {}
+  existing_apps = File.exist?(seed_app_filename) ? YAML.load_file(seed_app_filename) : {}
   auth_secret = "#{app_name}_development_#{SecureRandom.urlsafe_base64(32)}"
 
   existing_apps[app_name] = auth_secret

--- a/lib/tasks/seed_app.rake
+++ b/lib/tasks/seed_app.rake
@@ -1,5 +1,5 @@
 desc "Create a new seed app including a random auth_secret for local development"
-task :seed_app, [:app_name] do |t, opts|
+task :seed_app, [:app_name] do |_, opts|
   seed_app_filename = Rails.root.join('db/seed_apps.yml')
   app_name = opts[:app_name]
   unless app_name.present?

--- a/lib/tasks/seed_app.rake
+++ b/lib/tasks/seed_app.rake
@@ -1,0 +1,21 @@
+desc "Create a new seed app including a random auth_secret for local development"
+task :seed_app, [:app_name] do |t, opts|
+  seed_app_filename = Rails.root.join('db/seed_apps.yml')
+  app_name = opts[:app_name]
+  unless app_name.present?
+    puts "You must provide an app_name argument, e.g. rake seed_app[my_fantastic_app]"
+    next
+  end
+
+  existing_apps = File.exists?(seed_app_filename) ? YAML.load_file(seed_app_filename) : {}
+  auth_secret = "#{app_name}_development_#{SecureRandom.urlsafe_base64(32)}"
+
+  existing_apps[app_name] = auth_secret
+  File.open(seed_app_filename, 'w') { |f| f.write(YAML.dump(existing_apps)) }
+
+  Rake::Task["db:seed"].invoke
+
+  puts "\n#{app_name} configured in db/seed_apps.yml and loaded into your database.\n\n"
+  puts "Set the following environment variable in your app (e.g. via .powenv):\n\n"
+  puts "export TEST_TRACK_API_URL=http://#{app_name}:#{auth_secret}@testtrack.dev/\n\n"
+end


### PR DESCRIPTION
/domain @samandmoore @rynonl @nonrational @joejansen

This PR introduces a `db/seeds.rb` file that loads a `.gitignore`d YAML file that is expected to contain a serialized hash of app-name/auth_secret pairs to allow injection of local dev app seeds via laptop config management (e.g. boxen).

It also includes a rake task `rake seed_app[`*app_name*`]` that will idempotently create/update the YAML file and append/regenerate an app seed with a random password to the `app_seeds.yml`, and load it into the current environment's database (usually `development`).

The console output of running `rake seed_app[foo_app]` looks something like this:

```
Ensured foo_app app

foo_app configured in db/seed_apps.yml and loaded into your database.

Set the following environment variable in your app (e.g. via .powenv):

export TEST_TRACK_API_URL=http://foo_app:foo_app_development_hGH66uw532yaX6YiqvXN8ObOSLTn8R8jpwyrXgiKB18@testtrack.dev/
```

and it drops or appends to a `db/app_seeds.yml` file that looks like this:

```
---
foo_app: foo_app_development_hGH66uw532yaX6YiqvXN8ObOSLTn8R8jpwyrXgiKB18
```

The long password is necessary because we require long `auth_secrets` to prevent devs from shooting themselves in the foot with a weak passphrase, and since it has to be long, it might as well be credibly entropic even though it's just a local dev secret, in case somebody decides to use one of these in production.