### PR TITLE
Allow bulk assignments to decide variant

### DIFF
--- a/app/models/deterministic_assignment_creation.rb
+++ b/app/models/deterministic_assignment_creation.rb
@@ -8,6 +8,7 @@ class DeterministicAssignmentCreation
     @split_name = params[:split_name]
     @mixpanel_result = params[:mixpanel_result]
     @context = params[:context]
+    @bulk_assignment_id = params[:bulk_assignment_id]
     raise "Deterministic assignments must not specify a variant." if params[:variant]
   end
 
@@ -21,7 +22,8 @@ class DeterministicAssignmentCreation
       split_name: split_name,
       variant: variant,
       mixpanel_result: mixpanel_result,
-      context: context)
+      context: context,
+      bulk_assignment_id: bulk_assignment_id)
   end
 
   def variant

--- a/app/views/admin/bulk_assignments/new.html.erb
+++ b/app/views/admin/bulk_assignments/new.html.erb
@@ -28,7 +28,7 @@
         <%= f.input :identifier_type_id, wrapper_html: { class: "col-sm-4" }, label: 'Identified By', collection: identifier_types, label_method: :name, value_method: :id, include_blank: true %>
     </div>
     <div class="row">
-        <%= f.input :variant, wrapper_html: { class: "col-sm-4" }, label: 'To Variant', collection: @split.variants, include_blank: true %>
+        <%= f.input :variant, wrapper_html: { class: "col-sm-4" }, label: 'To Variant (if left blank, will assign as if the visitor experienced the split, and will not overwrite existing assignments)', collection: @split.variants, include_blank: true %>
     </div>
     <div class="row">
         <%= f.input :reason, placeholder: "e.g. Turn FeatureX on", wrapper_html: { class: "col-sm-6" } %>

--- a/db/migrate/20161031170611_remove_bulk_assignment_variant_null_constraint.rb
+++ b/db/migrate/20161031170611_remove_bulk_assignment_variant_null_constraint.rb
@@ -1,0 +1,5 @@
+class RemoveBulkAssignmentVariantNullConstraint < ActiveRecord::Migration
+  def change
+    change_column :bulk_assignments, :variant, :string, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161020190742) do
+ActiveRecord::Schema.define(version: 20161031170611) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 20161020190742) do
     t.integer  "admin_id",   null: false
     t.string   "reason",     null: false
     t.uuid     "split_id",   null: false
-    t.string   "variant",    null: false
+    t.string   "variant"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
/domain @aburgel 
/platform @jmileham 

This allows for `variant` to be left blank on bulk assignments. If it is blank, the bulk_assignment will run the variant calculator and assign visitors as if they'd actually experienced the split. It also will not override existing assignments since these would have been deterministically decided already, or overridden via the chrome plugin which we want to honor.