### PR TITLE
Batch decisions

### DIFF
--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -6,7 +6,9 @@ class Admin::DecisionsController < AuthenticatedAdminController
 
   def create
     @split = Split.find params[:split_id]
-    @decision = @split.create_decision!(create_params)
+    Split.transaction do # FIXME: This makes sure this controller either succeeds or fails atomically until we can async the work
+      @decision = @split.create_decision!(create_params)
+    end
     flash[:success] = "Reassigned #{@decision.count} visitors to #{@decision.variant}"
     redirect_to admin_split_path(@split)
   end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -32,9 +32,9 @@ class Decision
   end
 
   def reassign_existing_assignments
-    transaction do
-      bulk_assignment.save!
-      BulkReassignment.create!(assignments: existing_assignments, bulk_assignment: bulk_assignment)
+    bulk_assignment.save!
+    existing_assignments.find_in_batches do |subset|
+      BulkReassignment.create!(assignments: subset, bulk_assignment: bulk_assignment)
     end
   end
 

--- a/app/views/api/assignment_registries/show.json.jbuilder
+++ b/app/views/api/assignment_registries/show.json.jbuilder
@@ -1,3 +1,0 @@
-@assignments.each do |assignment|
-  json.set! assignment.split.name, assignment.variant
-end

--- a/app/views/api/identifier_visitors/show.json.jbuilder
+++ b/app/views/api/identifier_visitors/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! 'api/visitors/show', visitor: @visitor

--- a/app/views/api/identifiers/create.json.jbuilder
+++ b/app/views/api/identifiers/create.json.jbuilder
@@ -1,3 +1,0 @@
-json.visitor do
-  json.partial!('api/visitors/show', visitor: @identifier.visitor)
-end

--- a/app/views/api/split_registries/show.json.jbuilder
+++ b/app/views/api/split_registries/show.json.jbuilder
@@ -1,3 +1,0 @@
-@active_splits.each do |split|
-  json.set! split.name, split.registry
-end

--- a/app/views/api/v1/visitors/_show.json.jbuilder
+++ b/app/views/api/v1/visitors/_show.json.jbuilder
@@ -1,2 +1,2 @@
 json.(visitor, :id)
-json.assignments visitor.assignments.includes(:split), :split_name, :variant, :context, :unsynced
+json.assignments visitor.assignments.includes(:split).order(:created_at), :split_name, :variant, :context, :unsynced

--- a/app/views/api/visitors/_show.json.jbuilder
+++ b/app/views/api/visitors/_show.json.jbuilder
@@ -1,4 +1,0 @@
-json.(visitor,
-  :id,
-  :assignment_registry)
-json.unsynced_splits visitor.unsynced_splits.map(&:name)

--- a/app/views/api/visitors/show.json.jbuilder
+++ b/app/views/api/visitors/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! 'api/visitors/show', visitor: @visitor


### PR DESCRIPTION
/domain @Betterment/test_track_core 

There are a couple other things in here - there are dead templates related to long dead routes I removed because I saw them. Also, a test was relying on created_at return sequence of assignments in the visitor. The performance tradeoff should be tiny to make those deterministic, even without an index on created_at, because a visitor has a very small number of assignments to return.