### PR TITLE
rely on external supervisor for puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -11,8 +11,6 @@ else
   thread_count = Integer(ENV.fetch('PUMA_THREAD_COUNT'))
   threads thread_count, thread_count
   bind 'unix:///var/run/puma/testtrack.sock'
-  daemonize true
-  pidfile '/var/run/puma/testtrack.pid'
 end
 
 preload_app!


### PR DESCRIPTION
/domain @jmileham 

since we've got a Procfile now and we're endorsing foreman-backed deployment processes that include their own process supervisor, we don't need nor want to daemonize our puma process nor track its PID.