### PR TITLE
move the split decision execution into an activejob

### DIFF
--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -6,15 +6,15 @@ class Admin::DecisionsController < AuthenticatedAdminController
 
   def create
     split = Split.find params[:split_id]
-    affected_assignments = split.assignments.where.not(variant: target_variant)
+    affected_assignments_count = split.assignments.where.not(variant: target_variant).count
     CreateDecisionJob.perform_later(split, variant: target_variant, admin: current_admin)
-    flash[:success] = "Queued decision to reassign #{affected_assignments.count} visitors to #{target_variant}"
+    flash[:success] = "Queued decision to reassign #{affected_assignments_count} visitors to #{target_variant}"
     redirect_to admin_split_path(split)
   end
 
   private
 
   def target_variant
-    params.require(:decision).fetch(:variant)
+    params.require(:decision).permit(:variant).fetch(:variant)
   end
 end

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -5,14 +5,20 @@ class Admin::DecisionsController < AuthenticatedAdminController
   end
 
   def create
-    split = Split.find params[:split_id]
-    affected_assignments_count = split.assignments.where.not(variant: target_variant).count
     CreateDecisionJob.perform_later(split, variant: target_variant, admin: current_admin)
     flash[:success] = "Queued decision to reassign #{affected_assignments_count} visitors to #{target_variant}"
     redirect_to admin_split_path(split)
   end
 
   private
+
+  def affected_assignments_count
+    @affected_assignments_count ||= split.assignments.where.not(variant: target_variant).count
+  end
+
+  def split
+    @split ||= Split.find params[:split_id]
+  end
 
   def target_variant
     params.require(:decision).permit(:variant).fetch(:variant)

--- a/app/controllers/admin/decisions_controller.rb
+++ b/app/controllers/admin/decisions_controller.rb
@@ -5,20 +5,13 @@ class Admin::DecisionsController < AuthenticatedAdminController
   end
 
   def create
+    split = Split.find params[:split_id]
     CreateDecisionJob.perform_later(split, variant: target_variant, admin: current_admin)
-    flash[:success] = "Queued decision to reassign #{affected_assignments_count} visitors to #{target_variant}"
+    flash[:success] = "Queued decision to reassign all visitors to #{target_variant}"
     redirect_to admin_split_path(split)
   end
 
   private
-
-  def affected_assignments_count
-    @affected_assignments_count ||= split.assignments.where.not(variant: target_variant).count
-  end
-
-  def split
-    @split ||= Split.find params[:split_id]
-  end
 
   def target_variant
     params.require(:decision).permit(:variant).fetch(:variant)

--- a/app/jobs/create_decision_job.rb
+++ b/app/jobs/create_decision_job.rb
@@ -1,0 +1,5 @@
+class CreateDecisionJob < ActiveJob::Base
+  def perform(split, params)
+    split.create_decision!(params)
+  end
+end

--- a/app/jobs/create_decision_job.rb
+++ b/app/jobs/create_decision_job.rb
@@ -1,5 +1,5 @@
 class CreateDecisionJob < ActiveJob::Base
-  def perform(split, params)
-    split.create_decision!(params)
+  def perform(split, attrs)
+    split.create_decision!(attrs)
   end
 end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -9,8 +9,6 @@ class Decision
 
   validate :variant_belongs_to_split
 
-  delegate :transaction, to: BulkAssignment
-
   def save!
     raise errors.full_messages.to_sentence unless valid?
 

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -19,7 +19,7 @@ class Decision
   end
 
   def count
-    raise "count unavailable for unsaved Decision" unless bulk_assignment
+    raise "count unavailable for unsaved Decision" unless bulk_assignment.persisted?
     bulk_assignment.assignments.count
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module TestTrack
     config.log_tags = [:host, :uuid]
 
     config.cache_store = :memory_store
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/spec/features/admin_split_decision_create_spec.rb
+++ b/spec/features/admin_split_decision_create_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe 'split decision flow' do
     end
 
     expect(split_page).to be_displayed
+    expect(split_page).to have_content "Queued decision"
+
+    Delayed::Worker.new.work_off
+
+    split_page.load split_id: split.id
+    expect(split_page).to be_displayed
 
     expect(Assignment.where(variant: "hammer_time").count).to eq 0
     expect(Assignment.where(variant: "touch_this").count).to eq 5


### PR DESCRIPTION
this operation can take a long time to execute on a split that has lots
of assignments to reassign. this change pushes the execution of
reassignment into a background job. this change also trades off
guarantees that we only create a single BulkAssignment for the Decision.
in the non-optimal case, the job will die while executing the
reassignments in batches. when that happens, the job will re-run and
pick up the reassignment process where it left off with the one
unfortunate side effect of creating another BulkAssignment.

/domain @jmileham @rynonl 

Note: this PR also introduces ActiveJob over using `split.delay.create_decision!(...)`. I may have gotten the joint wrong, but it feels okay. 