### PR TITLE
Add table and edit form for variant metadata

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,4 +7,4 @@ indent_style = space
 indent_size = 2
 
 [*.erb]
-indent_size = 4
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,3 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
-
-[*.erb]
-indent_size = 2

--- a/app/controllers/admin/splits_controller.rb
+++ b/app/controllers/admin/splits_controller.rb
@@ -4,6 +4,6 @@ class Admin::SplitsController < AuthenticatedAdminController
   end
 
   def show
-    @split = Split.find params[:id]
+    @split = SplitPresenter.new(Split.find(params[:id]))
   end
 end

--- a/app/controllers/admin/variant_details_controller.rb
+++ b/app/controllers/admin/variant_details_controller.rb
@@ -1,4 +1,4 @@
-class Admin::VariantDetailsController < ApplicationController
+class Admin::VariantDetailsController < AuthenticatedAdminController
   def edit
     @split = Split.find(params[:split_id])
     @variant_detail = @split.variant_details.find_or_initialize_by(variant: params[:id])

--- a/app/controllers/admin/variant_details_controller.rb
+++ b/app/controllers/admin/variant_details_controller.rb
@@ -1,0 +1,24 @@
+class Admin::VariantDetailsController < ApplicationController
+  def edit
+    @split = Split.find(params[:split_id])
+    @variant_detail = @split.variant_details.find_or_initialize_by(variant: params[:id])
+  end
+
+  def update
+    @split = Split.find(params[:split_id])
+    @variant_detail = @split.variant_details.find_or_initialize_by(variant: params[:id])
+
+    if @variant_detail.update update_params
+      flash[:success] = "Details for #{@variant_detail.variant} have been saved."
+      redirect_to admin_split_path(@split)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def update_params
+    params.require(:variant_detail).permit(:display_name, :description)
+  end
+end

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -4,6 +4,7 @@ class Split < ActiveRecord::Base
   has_many :previous_split_registries
   has_many :assignments
   has_many :bulk_assignments
+  has_many :variant_details
 
   validates :name, presence: true, uniqueness: true
   validates :registry, presence: true
@@ -29,12 +30,6 @@ class Split < ActiveRecord::Base
 
   def variants
     registry ? registry.keys : []
-  end
-
-  def variant_details
-    variants.map do |variant|
-      VariantDetail.new(self, variant).freeze
-    end
   end
 
   def variant_weight(variant)

--- a/app/models/variant_detail.rb
+++ b/app/models/variant_detail.rb
@@ -2,6 +2,7 @@ class VariantDetail < ActiveRecord::Base
   belongs_to :split
 
   validate :variant_must_exist, on: :create
+  validates :display_name, :description, presence: true
 
   def display_name
     super || variant

--- a/app/models/variant_detail.rb
+++ b/app/models/variant_detail.rb
@@ -1,14 +1,15 @@
-class VariantDetail
-  attr_reader :split, :variant, :weight, :assignment_count
+class VariantDetail < ActiveRecord::Base
+  belongs_to :split
 
-  def initialize(split, variant)
-    @split = split
-    @variant = variant
-    @weight = split.variant_weight(variant)
-    @assignment_count = split.assignment_count_for_variant(variant)
+  validate :variant_must_exist, on: :create
+
+  def display_name
+    super || variant
   end
 
-  def retirable?
-    weight == 0 && assignment_count > 0
+  private
+
+  def variant_must_exist
+    errors.add(:base, "Variant does not exist: #{variant}") unless split.has_variant?(variant)
   end
 end

--- a/app/models/variant_detail.rb
+++ b/app/models/variant_detail.rb
@@ -1,7 +1,7 @@
 class VariantDetail < ActiveRecord::Base
   belongs_to :split
 
-  validate :variant_must_exist, on: :create
+  validate :variant_must_exist
   validates :display_name, :description, presence: true
 
   def display_name

--- a/app/presenters/split_presenter.rb
+++ b/app/presenters/split_presenter.rb
@@ -1,0 +1,8 @@
+class SplitPresenter < SimpleDelegator
+  def variant_details
+    variants.map do |variant|
+      detail = VariantDetail.find_or_initialize_by(split: __getobj__, variant: variant)
+      VariantPresenter.new(detail)
+    end
+  end
+end

--- a/app/presenters/variant_presenter.rb
+++ b/app/presenters/variant_presenter.rb
@@ -1,0 +1,13 @@
+class VariantPresenter < SimpleDelegator
+  def weight
+    @weight ||= split.variant_weight(variant)
+  end
+
+  def assignment_count
+    @assignment_count ||= split.assignment_count_for_variant(variant)
+  end
+
+  def retirable?
+    weight == 0 && assignment_count > 0
+  end
+end

--- a/app/views/admin/splits/_variants.html.erb
+++ b/app/views/admin/splits/_variants.html.erb
@@ -10,6 +10,7 @@
         <th>Name</th>
         <th>Weight</th>
         <th>Assignee Count</th>
+        <th></th>
       </thead>
       <tbody>
         <% @split.variant_details.each do |variant_detail| %>
@@ -28,6 +29,7 @@
                         EOF
               <% end %>
             </td>
+            <td><%= link_to 'edit', edit_admin_split_variant_detail_path(@split, variant_detail.variant) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/splits/_variants.html.erb
+++ b/app/views/admin/splits/_variants.html.erb
@@ -1,7 +1,7 @@
 <article class="InfoCard sc-m-v--l">
   <div class="InfoCard-titleContainer">
     <h4>Variant Details</h4>
-    <%= link_to "Edit", new_admin_split_split_config_path(@split), class: 'change-weights-link' %>
+    <%= link_to "Edit", new_admin_split_split_config_path(split), class: 'change-weights-link' %>
   </div>
   <hr class="InfoCard-divider">
   <div class="InfoCard-description">
@@ -13,14 +13,14 @@
         <th></th>
       </thead>
       <tbody>
-        <% @split.variant_details.each do |variant_detail| %>
+        <% split.variant_details.each do |variant_detail| %>
           <tr>
             <td><%= variant_detail.variant %></td>
             <td><%= variant_detail.weight %>%</td>
             <td>
               <%= variant_detail.assignment_count %>
               <% if variant_detail.retirable? %>
-              (<%= link_to "Retire variant", admin_split_variant_retirement_path(@split, variant_detail.variant),
+              (<%= link_to "Retire variant", admin_split_variant_retirement_path(split, variant_detail.variant),
                 class: "retire-variant-link",
                         method: :post,
                         data: { confirm: <<-EOF } %>)
@@ -29,7 +29,7 @@
                         EOF
               <% end %>
             </td>
-            <td><%= link_to 'edit', edit_admin_split_variant_detail_path(@split, variant_detail.variant) %></td>
+            <td><%= link_to 'edit', edit_admin_split_variant_detail_path(split, variant_detail.variant) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/variant_details/edit.html.erb
+++ b/app/views/admin/variant_details/edit.html.erb
@@ -1,8 +1,10 @@
+<% content_for :page_title, "Split Details: #{@split.name}" %>
+
 <div class="TakeoverText">
   <h1 class="TakeoverText-title">Details for variant: <%= @variant_detail.variant %></h1>
 </div>
 
-<div class="form-container sc-m-t--l"%>
+<div class="InfoCard"%>
   <%= simple_form_for @variant_detail, url: admin_split_variant_detail_path(@split, @variant_detail.variant), method: :put do |f| %>
     <%= f.error :base %>
     <%= f.input :display_name %>

--- a/app/views/admin/variant_details/edit.html.erb
+++ b/app/views/admin/variant_details/edit.html.erb
@@ -1,0 +1,18 @@
+<div class="TakeoverText">
+  <h1 class="TakeoverText-title">Details for variant: <%= @variant_detail.variant %></h1>
+</div>
+
+<div class="form-container sc-m-t--l"%>
+  <%= simple_form_for @variant_detail, url: admin_split_variant_detail_path(@split, @variant_detail.variant), method: :put do |f| %>
+    <%= f.error :base %>
+    <%= f.input :display_name %>
+    <%= f.input :description, label: 'Short description', hint: 'For example: There are FAQ links in a sidebar on the Activity Tab' %>
+
+    <div class="sc-TakeoverFooter">
+      <div class="sc-TakeoverFooter-content">
+        <%= link_to 'Back', admin_split_path(@split), class: 'sc-TakeoverFooter-ctaBack sc-Link sc-Link--arrowLeft ft-backButton' %>
+        <%= f.submit 'Continue', data: { disable_with: 'Updating variant...' }, class: 'u-button ft-confirmButton' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Test Track Admin</title>
+  <title><%= page_title %></title>
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1.0 maximum-scale=1.0, user-scalable=0">
   <%= favicon_link_tag '/favicon.ico' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,6 +3,9 @@
     <figure class="sc-TakeoverHeader-logoContainer sc-p--xs">
       <%= link_to(image_tag('ttlogo.png', size: "47x47"), admin_root_url) %>
     </figure>
+    <div class="sc-TakeoverHeader-title">
+      <%= page_title %>
+    </div>
   </div>
   <% if signed_in? %>
     <div class="sc-TakeoverHeader-cta">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
       resources :variants, only: [] do
         resource :retirement, only: [:create], controller: 'variant_retirements'
       end
+      resources :variant_details, only: [:edit, :update]
     end
   end
 end

--- a/db/migrate/20170316204717_create_variant_details.rb
+++ b/db/migrate/20170316204717_create_variant_details.rb
@@ -1,0 +1,15 @@
+class CreateVariantDetails < ActiveRecord::Migration
+  def change
+    create_table :variant_details, id: :uuid do |t|
+      t.uuid :split_id, null: false, index: true
+      t.string :variant, null: false
+      t.string :display_name
+      t.text :description
+
+      t.timestamps null: false
+    end
+
+    add_foreign_key :variant_details, :splits
+    add_index :variant_details, [:split_id, :variant], unique: true
+  end
+end

--- a/db/migrate/20170316204717_create_variant_details.rb
+++ b/db/migrate/20170316204717_create_variant_details.rb
@@ -3,8 +3,8 @@ class CreateVariantDetails < ActiveRecord::Migration
     create_table :variant_details, id: :uuid do |t|
       t.uuid :split_id, null: false, index: true
       t.string :variant, null: false
-      t.string :display_name
-      t.text :description
+      t.string :display_name, null: false
+      t.text :description, null: false
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20170317155628) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -155,6 +154,18 @@ ActiveRecord::Schema.define(version: 20170317155628) do
   add_index "splits", ["name"], name: "index_splits_on_name", unique: true, using: :btree
   add_index "splits", ["owner_app_id"], name: "index_splits_on_owner_app_id", using: :btree
 
+  create_table "variant_details", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.uuid     "split_id",     null: false
+    t.string   "variant",      null: false
+    t.string   "display_name"
+    t.text     "description"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+  end
+
+  add_index "variant_details", ["split_id", "variant"], name: "index_variant_details_on_split_id_and_variant", unique: true, using: :btree
+  add_index "variant_details", ["split_id"], name: "index_variant_details_on_split_id", using: :btree
+
   create_table "visitor_supersessions", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.uuid     "superseded_visitor_id",  null: false
     t.uuid     "superseding_visitor_id", null: false
@@ -184,6 +195,7 @@ ActiveRecord::Schema.define(version: 20170317155628) do
   add_foreign_key "previous_assignments", "visitor_supersessions"
   add_foreign_key "previous_split_registries", "splits"
   add_foreign_key "splits", "apps", column: "owner_app_id"
+  add_foreign_key "variant_details", "splits"
   add_foreign_key "visitor_supersessions", "visitors", column: "superseded_visitor_id"
   add_foreign_key "visitor_supersessions", "visitors", column: "superseding_visitor_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20170317155628) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"

--- a/spec/factories/variant_details.rb
+++ b/spec/factories/variant_details.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :variant_detail do
+    split
+    variant { split.variants.first }
+    display_name 'Great variant'
+    description 'Really, everyone loves it'
+  end
+end

--- a/spec/features/admin_split_config_create_spec.rb
+++ b/spec/features/admin_split_config_create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'admin can change weights for split variants' do
   it 'allows admins to change the weights of a split' do
     split_page.load split_id: split.id
     expect(split_page).to be_displayed
-    expect(split_page.variants_table).to have_content "red 100% 0 blue 0% 0"
+    expect(split_page.variants_table).to have_content "red 100% 0 edit blue 0% 0 edit"
 
     split_page.change_weights.click
 
@@ -45,6 +45,6 @@ RSpec.describe 'admin can change weights for split variants' do
       end
       form.submit_button.click
     end
-    expect(split_page.variants_table).to have_content "red 50% 0 blue 50% 0"
+    expect(split_page.variants_table).to have_content "red 50% 0 edit blue 50% 0 edit"
   end
 end

--- a/spec/features/admin_variant_details_edit_spec.rb
+++ b/spec/features/admin_variant_details_edit_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'admin can edit variant details' do
+  let(:split_page) { app.admin_split_show_page }
+  let(:variant_page) { app.admin_variant_details_edit_page }
+
+  let!(:split) { FactoryGirl.create(:split, name: 'great_feature', registry: { enabled: 100 }) }
+
+  before do
+    login
+  end
+
+  it 'allows admins to edit variant details' do
+    split_page.load split_id: split.id
+    expect(split_page).to be_displayed
+
+    expect(split_page.variants.count).to eq 1
+    split_page.variants.first.edit_link.click
+
+    expect(variant_page).to be_displayed
+
+    variant_page.form.display_name.set 'Variant name'
+    variant_page.form.description.set 'Super great variant'
+    variant_page.form.submit_button.click
+
+    expect(split_page).to be_displayed
+    expect(split_page).to have_content 'Details for enabled have been saved'
+  end
+end

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -129,24 +129,6 @@ RSpec.describe Split, type: :model do
     end
   end
 
-  describe "#variant_details" do
-    it "returns an array of frozen VariantDetails" do
-      split = FactoryGirl.create(:split, registry: { control: 40, treatment: 60 })
-
-      variant_details = split.variant_details
-
-      expect(variant_details.size).to eq 2
-
-      expect(variant_details.first.variant).to eq "control"
-      expect(variant_details.first.weight).to eq 40
-      expect(variant_details.first).to be_frozen
-
-      expect(variant_details.second.variant).to eq "treatment"
-      expect(variant_details.second.weight).to eq 60
-      expect(variant_details.second).to be_frozen
-    end
-  end
-
   describe "#assignment_count_for_variant" do
     it "returns count of given variant" do
       FactoryGirl.create(:assignment, split: subject, variant: "treatment")

--- a/spec/models/variant_detail_spec.rb
+++ b/spec/models/variant_detail_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe VariantDetail do
 
   describe '#valid?' do
     context 'with a variant that exists' do
-      subject { described_class.new(split: split, variant: 'true') }
+      subject { FactoryGirl.build(:variant_detail, split: split, variant: 'true') }
 
       it 'returns true' do
         expect(subject.valid?).to eq true
@@ -13,7 +13,7 @@ RSpec.describe VariantDetail do
     end
 
     context 'with a variant that does not exist' do
-      subject { described_class.new(split: split, variant: 'duck') }
+      subject { FactoryGirl.build(:variant_detail, split: split, variant: 'duck') }
 
       it 'returns false' do
         expect(subject.valid?).to eq false

--- a/spec/models/variant_detail_spec.rb
+++ b/spec/models/variant_detail_spec.rb
@@ -1,49 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe VariantDetail do
-  describe "#weight" do
-    it "is the weight of the given variant" do
-      split = FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 40, false: 60 })
-      expect(described_class.new(split, "true").weight).to eq 40
-    end
-  end
+  let(:split) { FactoryGirl.create(:split, name: 'split_enabled', registry: { true: 50, false: 50 }) }
 
-  describe "#assignment_count" do
-    it "is the number of assignments of given variant" do
-      split = FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 40, false: 60 })
-      FactoryGirl.create(:assignment, split: split, variant: "true")
-      FactoryGirl.create_pair(:assignment, split: split, variant: "false")
+  describe '#valid?' do
+    context 'with a variant that exists' do
+      subject { described_class.new(split: split, variant: 'true') }
 
-      expect(described_class.new(split, "true").assignment_count).to eq 1
-      expect(described_class.new(split, "false").assignment_count).to eq 2
-    end
-  end
-
-  describe "#retirable?" do
-    it "is false for a 0% weight that has no assignments" do
-      split = FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 0, false: 100 })
-
-      expect(described_class.new(split, "true")).not_to be_retirable
+      it 'returns true' do
+        expect(subject.valid?).to eq true
+      end
     end
 
-    it "is true for a 0% weight that has assignments" do
-      split = FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 0, false: 100 })
-      FactoryGirl.create(:assignment, split: split, variant: "true")
+    context 'with a variant that does not exist' do
+      subject { described_class.new(split: split, variant: 'duck') }
 
-      expect(described_class.new(split, "true")).to be_retirable
-    end
-
-    it "is false for a non 0% weight with no assignments" do
-      split = FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 1, false: 99 })
-
-      expect(described_class.new(split, "true")).not_to be_retirable
-    end
-
-    it "is false for a non 0% weight that has assignments" do
-      split = FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 1, false: 99 })
-      FactoryGirl.create(:assignment, split: split, variant: "true")
-
-      expect(described_class.new(split, "true")).not_to be_retirable
+      it 'returns false' do
+        expect(subject.valid?).to eq false
+        expect(subject.errors[:base]).to include 'Variant does not exist: duck'
+      end
     end
   end
 end

--- a/spec/models/variant_presenter_spec.rb
+++ b/spec/models/variant_presenter_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe VariantPresenter do
+  let(:split) { FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 40, false: 60 }) }
+
+  describe "#weight" do
+    subject { described_class.new(VariantDetail.new(split: split, variant: 'true')) }
+
+    it "is the weight of the given variant" do
+      expect(subject.weight).to eq 40
+    end
+  end
+
+  describe "#assignment_count" do
+    let!(:true_assignment) { FactoryGirl.create(:assignment, split: split, variant: "true") }
+    let!(:false_assignment) { FactoryGirl.create_pair(:assignment, split: split, variant: "false") }
+
+    let(:true_presenter) { described_class.new(VariantDetail.new(split: split, variant: 'true')) }
+    let(:false_presenter) { described_class.new(VariantDetail.new(split: split, variant: 'false')) }
+
+    it "is the number of assignments of given variant" do
+      expect(true_presenter.assignment_count).to eq 1
+      expect(false_presenter.assignment_count).to eq 2
+    end
+  end
+
+  describe "#retirable?" do
+    subject { described_class.new(VariantDetail.new(split: split, variant: 'true')) }
+
+    context 'with a 0% weight' do
+      let(:split) { FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 0, false: 100 }) }
+
+      context 'with no assignments' do
+        it "is false" do
+          expect(subject).not_to be_retirable
+        end
+      end
+
+      context 'with some assignments' do
+        let!(:assignment) { FactoryGirl.create(:assignment, split: split, variant: "true") }
+
+        it "is true" do
+          expect(subject).to be_retirable
+        end
+      end
+    end
+
+    context 'with a non-0% weight' do
+      let(:split) { FactoryGirl.create(:split, name: "some_feature_enabled", registry: { true: 1, false: 99 }) }
+
+      context 'with no assignments' do
+        it "is false" do
+          expect(subject).not_to be_retirable
+        end
+      end
+
+      context 'with some assignments' do
+        let!(:assignment) { FactoryGirl.create(:assignment, split: split, variant: "true") }
+
+        it "is false for a non 0% weight that has assignments" do
+          expect(subject).not_to be_retirable
+        end
+      end
+    end
+  end
+end

--- a/spec/support/pages/admin/split_show_page.rb
+++ b/spec/support/pages/admin/split_show_page.rb
@@ -3,7 +3,11 @@ class AdminSplitShowPage < SitePrism::Page
 
   element :population_count, "tr.population-row span.population"
 
-  element :variants_table, ".variants-table"
+  element :variants_table, '.variants-table'
+
+  sections :variants, ".variants-table tbody tr" do
+    element :edit_link, 'td:nth-of-type(4) a'
+  end
 
   element :change_weights, ".change-weights-link"
   element :retire_variant, ".retire-variant-link"

--- a/spec/support/pages/admin/variant_details_edit_page.rb
+++ b/spec/support/pages/admin/variant_details_edit_page.rb
@@ -1,0 +1,9 @@
+class AdminVariantDetailsEditPage < SitePrism::Page
+  set_url '/admin/splits/{split_id}/variant_details/{variant}/edit'
+
+  section :form, 'form' do
+    element :display_name, 'input[name="variant_detail[display_name]"]'
+    element :description, 'textarea[name="variant_detail[description]"]'
+    element :submit_button, 'input[type=submit]'
+  end
+end


### PR DESCRIPTION
### Summary

Adding the data model and initial form for adding human-readable metadata to variants. I'd like to wait for @agirlnamedsophia to land her style changes before this gets merged, but I think it's ready to look at.

/domain @Betterment/test_track_core @agirlnamedsophia 
