### PR TITLE
Form support for new designs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,5 @@
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require style_closet
 //= require_tree .

--- a/app/inputs/collection_radio_buttons_input.rb
+++ b/app/inputs/collection_radio_buttons_input.rb
@@ -1,0 +1,75 @@
+class CollectionRadioButtonsInput < SimpleForm::Inputs::CollectionSelectInput
+  include ActionView::Helpers::OutputSafetyHelper
+  include RadioButton
+
+  def input(wrapper_options) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+    template.content_tag :ul, merged_input_options.merge(class: 'radio-options') do
+      radio_options = collection.map do |option|
+        label, value = option_label_value(option, collection_methods)
+
+        radio_button_options = option.is_a?(Hash) ? option : {}
+        radio_button_options[:value] = value
+        radio_button_options[:label] = label
+        radio_button_options[:description] = extract_from_option(option, description_method) if description_method
+        radio_button_options[:state] = if state_method
+                                         extract_from_option(option, state_method) || state(value)
+                                       else
+                                         state(value)
+                                       end
+
+        build_radio_button(radio_button_options)
+      end
+      radio_options << build_radio_button(value: '', label: blank_label, state: state('')) if options[:include_blank]
+      safe_join radio_options
+    end
+  end
+
+  private
+
+  def state(value)
+    if options.fetch(:selected, nil) == value
+      :selected
+    elsif selected?(value)
+      :selected
+    else
+      :unselected
+    end
+  end
+
+  def blank_label
+    if options[:include_blank].is_a? String
+      options[:include_blank]
+    else
+      'None of the above'
+    end
+  end
+
+  def collection_methods
+    @collection_methods ||= detect_collection_methods
+  end
+
+  def description_method
+    @description_method ||= options.delete(:description_method)
+  end
+
+  def state_method
+    @state_method ||= options.delete(:state_method)
+  end
+
+  def extract_from_option(option, method)
+    if option.nil?
+      ''
+    elsif method.is_a? Proc
+      method.call(option)
+    else
+      option.public_send(method)
+    end
+  end
+
+  def option_label_value(option, collection_methods)
+    collection_methods.map do |method|
+      extract_from_option option, method
+    end
+  end
+end

--- a/app/inputs/collection_select_input.rb
+++ b/app/inputs/collection_select_input.rb
@@ -1,0 +1,124 @@
+class CollectionSelectInput < SimpleForm::Inputs::CollectionSelectInput
+  include ActionView::Helpers::OutputSafetyHelper
+
+  def display_dropdown(_wrapper_options) # rubocop:disable Metrics/AbcSize
+    # unclear what the desired behavior would be if both of these options are set
+    raise 'You can only use one of :include_blank/:prompt' if options[:include_blank] && options[:prompt]
+
+    @builder.template.content_tag :ul do
+      dropdown_options = collection.map do |option|
+        label, value = option_label_value option
+
+        @builder.template.content_tag(:li, label, class: 'selectable', data: { value: value })
+      end
+
+      dropdown_options.unshift(blank_option_tag) if blank_option_label
+      safe_join dropdown_options
+    end
+  end
+
+  def input(wrapper_options)
+    label_method, value_method = collection_methods
+
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+
+    @builder.collection_select(
+      attribute_name, collection, value_method, label_method,
+      input_options, merged_input_options
+    )
+  end
+
+  def selected(_wrapper_options)
+    if options[:selected].present?
+      provided_selected_option_label
+    elsif selected_option_label.present?
+      selected_option_label
+    else
+      blank_option_label || extract_label(collection.first)
+    end
+  end
+
+  private
+
+  def provided_selected_option_label
+    extract_label find_selected(options[:selected])
+  end
+
+  def selected_option_label
+    extract_label find_selected(object.public_send(@attribute_name))
+  end
+
+  def find_selected(value)
+    collection.find do |option|
+      extract_from_option(option, value_method) == value || option == value
+    end
+  end
+
+  def blank_option_label
+    if prompt?
+      prompt_as_string
+    elsif include_blank?
+      include_blank_as_string
+    end
+  end
+
+  def blank_option_tag
+    @builder.template.content_tag(:li, blank_option_label, class: 'selectable', data: { value: '' })
+  end
+
+  def label_method
+    collection_methods.first
+  end
+
+  def value_method
+    collection_methods.second
+  end
+
+  def collection_methods
+    @_collection_methods ||= detect_collection_methods
+  end
+
+  def extract_label(option)
+    extract_from_option(option, label_method)
+  end
+
+  def extract_from_option(option, method)
+    if option.nil?
+      ''
+    elsif method.is_a? Proc
+      method.call(option)
+    else
+      option.public_send(method)
+    end
+  end
+
+  def option_label_value(option)
+    collection_methods.map do |method|
+      extract_from_option option, method
+    end
+  end
+
+  def prompt?
+    options[:prompt] && selected_option_label.blank?
+  end
+
+  def include_blank?
+    options[:include_blank] != false && options[:prompt].nil?
+  end
+
+  def include_blank_as_string
+    if options[:include_blank] == true || options[:include_blank].nil?
+      ''
+    else
+      options[:include_blank]
+    end
+  end
+
+  def prompt_as_string
+    if options[:prompt] == true
+      I18n.translate('helpers.select.prompt', default: 'Please select')
+    else
+      options[:prompt]
+    end
+  end
+end

--- a/app/inputs/grouped_collection_select_input.rb
+++ b/app/inputs/grouped_collection_select_input.rb
@@ -1,0 +1,95 @@
+class GroupedCollectionSelectInput < SimpleForm::Inputs::GroupedCollectionSelectInput
+  include ActionView::Helpers::OutputSafetyHelper
+
+  def display_dropdown(_wrapper_options)
+    safe_join build_dropdown
+  end
+
+  def selected(_wrapper_options)
+    selected_option ? option_label(selected_option) : options[:include_blank]
+  end
+
+  private
+
+  def selected_option
+    current_value = object.public_send(attribute_name)
+    @_selected ||= collections.find { |option| option_value(option) == current_value || option == current_value }
+  end
+
+  def collections
+    grouped_collection.flat_map { |collection| collection.try(:send, group_method) }
+  end
+
+  def build_dropdown
+    dropdown = grouped_collection.map do |parent|
+      @builder.template.content_tag(:div, class: 'group') { group_header(parent) + group_dropdown(parent) }
+    end
+    dropdown.unshift(blank_option) if options[:include_blank]
+    dropdown
+  end
+
+  def blank_option
+    css_classes = %w(selectable)
+    css_classes << 'selected' if selected_option.nil?
+    @builder.template.content_tag(:div, class: 'group') do
+      @builder.template.content_tag(:ul) do
+        @builder.template.content_tag(:li, options[:include_blank], class: css_classes.join(' '), data: { value: '' })
+      end
+    end
+  end
+
+  def group_header(parent)
+    @builder.template.content_tag(:h5, extract_from_option(parent, group_label_method))
+  end
+
+  def group_dropdown(parent)
+    group = parent.send(group_method) || []
+    dropdown = group.map do |option|
+      css_classes = %w(selectable)
+      css_classes << 'selected' if selected_option == option
+      @builder.template.content_tag(:li, option_label(option), class: css_classes.join(' '), data: { value: option_value(option) })
+    end
+    @builder.template.content_tag(:ul) { safe_join dropdown }
+  end
+
+  def label_method
+    @_label_method ||= collection_methods.first
+  end
+
+  def value_method
+    @_value_method ||= collection_methods.last
+  end
+
+  def collection_methods
+    @_collection_methods ||= detect_collection_methods
+  end
+
+  def option_label(option)
+    @builder.template.content_tag(:span, extract_from_option(option, label_method))
+  end
+
+  def option_value(option)
+    extract_from_option(option, value_method)
+  end
+
+  def group_label_method
+    @_group_label_method ||= options.delete(:group_label_method)
+
+    unless @_group_label_method
+      common_method_for = detect_common_display_methods(detect_collection_classes(grouped_collection))
+      @_group_label_method = common_method_for[:label]
+    end
+
+    @_group_label_method
+  end
+
+  def extract_from_option(option, method)
+    if option.nil?
+      ''
+    elsif method.is_a? Proc
+      method.call(option)
+    else
+      option.public_send(method)
+    end
+  end
+end

--- a/app/inputs/percent_input.rb
+++ b/app/inputs/percent_input.rb
@@ -1,0 +1,24 @@
+class PercentInput < SimpleForm::Inputs::Base
+  def input(wrapper_options)
+    merged_input_options = merge_wrapper_options(input_html_options, wrapper_options)
+    merged_input_options[:type] = 'number'
+    merged_input_options[:value] = value
+
+    @builder.text_field(attribute_name, merged_input_options)
+  end
+
+  def symbol(_wrapper_options)
+    '%'
+  end
+
+  private
+
+  def value
+    value = object.public_send(@attribute_name) if object
+    if value.nil?
+      options[:default]
+    else
+      value
+    end
+  end
+end

--- a/app/inputs/radio_button.rb
+++ b/app/inputs/radio_button.rb
@@ -1,0 +1,91 @@
+module RadioButton
+  include ActionView::Helpers::OutputSafetyHelper
+
+  def build_radio_button(options)
+    value = options[:value]
+    label = options[:label]
+    completed = options[:state] == :completed
+
+    if completed
+      build_completed_button(value, label, options)
+    else
+      build_uncompleted_button(value, label, options)
+    end
+  end
+
+  private
+
+  def build_completed_button(value, label, options) # rubocop:disable Metrics/AbcSize
+    description = options[:description]
+    completed_css_class = description ? 'with-description completed' : 'completed'
+
+    @builder.template.content_tag item_wrapper_tag, class: completed_css_class, data: { value: value } do
+      html = @builder.template.content_tag :div, class: "completed-radio-button" do
+        template.content_tag :div, class: "radio-check" do
+          @builder.template.content_tag(:img, nil, src: ActionController::Base.helpers.image_path('icons/checked_radio_button.svg'))
+        end
+      end
+      html << add_label(label) << add_description(description, false)
+    end
+  end
+
+  def build_uncompleted_button(value, label, options) # rubocop:disable Metrics/AbcSize
+    selected = options[:state] == :selected || selected?(value)
+    disabled = options[:state] == :disabled
+    description = options[:description]
+    css_class = css_class(selected, disabled)
+
+    @builder.template.content_tag item_wrapper_tag, class: css_class, data: { value: value } do
+      html = @builder.template.content_tag :div, class: "radio-button #{value}" do
+        template.radio_button(object_name, attribute_name, value, checked: selected, disabled: disabled)
+      end
+      html << add_label(label) << add_description(description, disabled)
+    end
+  end
+
+  def item_wrapper_tag_class
+    'radio-option'
+  end
+
+  def item_wrapper_tag
+    :li
+  end
+
+  def selected?(value)
+    value == selected_option
+  end
+
+  def selected_option
+    value = object.public_send(@attribute_name) if object
+    if value.nil?
+      options[:default]
+    else
+      value
+    end
+  end
+
+  def add_label(label)
+    @builder.template.content_tag(:label, label)
+  end
+
+  def add_description(description, disabled)
+    if description
+      @builder.template.content_tag(:div, description, class: description_class(disabled))
+    else
+      ActiveSupport::SafeBuffer.new
+    end
+  end
+
+  def description_class(disabled)
+    css_classes = ['radio-description']
+    css_classes << 'pending' if disabled
+    css_classes.join(' ')
+  end
+
+  def css_class(selected, disabled)
+    css_classes = [item_wrapper_tag_class]
+    css_classes << 'selected' if selected
+    css_classes << 'disabled' if disabled
+    css_classes.join(' ')
+  end
+end

--- a/app/inputs/radio_button_input.rb
+++ b/app/inputs/radio_button_input.rb
@@ -1,0 +1,7 @@
+class RadioButtonInput < SimpleForm::Inputs::Base
+  include RadioButton
+
+  def input(_wrapper_options)
+    build_radio_button(options)
+  end
+end

--- a/app/inputs/string_input.rb
+++ b/app/inputs/string_input.rb
@@ -1,0 +1,16 @@
+class StringInput < SimpleForm::Inputs::StringInput
+  def input(wrapper_options)
+    super(wrapper_options.merge(value: value))
+  end
+
+  private
+
+  def value
+    value = object.public_send(@attribute_name) if object
+    if value.nil?
+      options[:default]
+    else
+      value
+    end
+  end
+end

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -1,0 +1,5 @@
+Date::DATE_FORMATS[:slashed_full_date] = '%-m/%-d/%Y'
+Time::DATE_FORMATS[:slashed_full_date] = '%-m/%-d/%Y'
+
+Date::DATE_FORMATS[:timestamp_in_utc] = '%H:%M %Z'
+Time::DATE_FORMATS[:timestamp_in_utc] = '%H:%M %Z'

--- a/vendor/gems/style-closet/app/assets/javascripts/style-closet/base_inputs.js
+++ b/vendor/gems/style-closet/app/assets/javascripts/style-closet/base_inputs.js
@@ -1,0 +1,9 @@
+(function() {
+  $(document).on('focus', '[data-behavior="input"]', function (e) {
+    $(this).addClass('active');
+  });
+
+  $(document).on('blur', '[data-behavior="input"]', function (e) {
+    $(this).removeClass('active');
+  });
+}());

--- a/vendor/gems/style-closet/app/assets/javascripts/style-closet/dropdowns.js
+++ b/vendor/gems/style-closet/app/assets/javascripts/style-closet/dropdowns.js
@@ -1,0 +1,74 @@
+(function() {
+  var toggleDropdown = function (e) {
+    e.preventDefault();
+    var $inputDiv = $(this).closest('[data-behavior="dropdown"]');
+    if ($inputDiv.hasClass('open')) {
+      closeDropdown.apply(this);
+    } else {
+      openDropdown.apply(this);
+    }
+  };
+
+  var openDropdown = function () {
+    var $inputDiv = $(this).closest('[data-behavior="dropdown"]');
+    $inputDiv.addClass('active open');
+    $inputDiv.find('.select-options').focus();
+  };
+
+  var closeDropdown = function (e) {
+    if ($(e.target).is('[type="checkbox"]')) {
+      return true;
+    }
+
+    var $inputDiv = $(this).closest('[data-behavior="dropdown"]');
+    $inputDiv.removeClass('open');
+    if ($inputDiv.data().multiSelect) {
+      updateSelectCheckboxPlaceholder($inputDiv);
+    } else {
+      var isEmpty = ($inputDiv.find('select').val() === '');
+      $inputDiv.toggleClass('active', isEmpty);
+    }
+  };
+
+  var updateFakeSelect = function (value, $inputDiv) {
+    var $option = $inputDiv.find('.select-options li[data-value="' + value + '"]');
+    var label = $option.text();
+
+    $inputDiv.find('.selectable').removeClass('selected');
+    $option.addClass('selected');
+    $inputDiv.find('.display-selected').html('<span>' + label + '</span>');
+    $inputDiv.addClass('active').removeClass('open');
+  };
+
+  var updateSelectCheckboxPlaceholder = function ($inputDiv) {
+    var $checked = $inputDiv.find('input:checked'),
+        $selected = $inputDiv.find('.display-selected'),
+        label = $inputDiv.children('label').text(),
+        placeholder = 'Add ' + label;
+    if ($checked.length === 1) {
+      placeholder = $checked.first().siblings('label').text();
+    } else if ($checked.length > 1) {
+      placeholder = $checked.length + ' ' + label;
+    }
+    $selected.text(placeholder);
+  };
+
+  var optionSelected = function () {
+    if ($(this).hasClass('input-check')) {
+      $(this).find('[type="checkbox"]').click();
+    } else {
+      var $inputDiv = $(this).closest('[data-behavior="dropdown"]');
+      var value = $(this).data('value');
+      $inputDiv.find('select').val(value).change();
+    }
+  };
+
+  var selectChanged = function () {
+    updateFakeSelect($(this).val(), $(this).closest('[data-behavior="dropdown"]'));
+  };
+
+  $(document).on('mousedown', '[data-behavior="dropdown"] .display-selected', toggleDropdown);
+  $(document).on('blur focusout', '[data-behavior="dropdown"] .select-options', closeDropdown);
+  $(document).on('click', '[data-behavior="dropdown"] .select-options li.selectable', optionSelected);
+  $(document).on('change', '[data-behavior="dropdown"] select', selectChanged);
+}());

--- a/vendor/gems/style-closet/app/assets/javascripts/style-closet/flashes.js
+++ b/vendor/gems/style-closet/app/assets/javascripts/style-closet/flashes.js
@@ -1,0 +1,7 @@
+(function() {
+  $(document).on('click', '.sc-flash [data-behavior~="close-flash"]', function(e) {
+    var $flash = $(e.target).closest('.sc-flash');
+
+    $flash.hide();
+  });
+}());

--- a/vendor/gems/style-closet/app/assets/javascripts/style-closet/radio_buttons.js
+++ b/vendor/gems/style-closet/app/assets/javascripts/style-closet/radio_buttons.js
@@ -1,0 +1,26 @@
+(function() {
+  var selectRadioButton = function (e) {
+    var $button = $(this),
+      $radioSet = $button.closest('[data-behavior~="radio"]'),
+      $hiddenInput = $button.find('input'),
+      name = $hiddenInput.attr('name'),
+      $buttonsInGroup = $radioSet.find('input[name="' + name + '"]').closest('.radio-option');
+
+    $hiddenInput.prop('checked', true).change();
+    $buttonsInGroup.removeClass('selected');
+    $button.addClass('selected');
+  };
+
+  $(document).on('click', '[data-behavior~="radio"] .radio-option:not(".disabled")', selectRadioButton);
+  $(document).on('click', '[data-behavior~="radio"] .radio-options:not(".disabled") tr', selectRadioButton);
+
+  $(document).on('click', '[data-behavior~="nested-radio"] li:not(".nested-radio-group")', function (e) {
+    var $children = $(this).next('.nested-radio-group').find('li'),
+      $adjacentSelectedButtons = $(this).siblings('li.selected');
+
+    $children.first().click();
+
+    $adjacentSelectedButtons.removeClass('selected');
+    $adjacentSelectedButtons.find('input').prop('checked', false).change();
+  });
+}());

--- a/vendor/gems/style-closet/app/assets/javascripts/style_closet.js
+++ b/vendor/gems/style-closet/app/assets/javascripts/style_closet.js
@@ -1,0 +1,1 @@
+//= require ./style_closet/


### PR DESCRIPTION
Summary of Changes
* new javascript files and their related form helpers to support new designs. waiting for the next PR to implement these forms with full deprecation of bootstrap
* added datetime helpers to support new designs
* added layout helper methods to support new layout styles (to be implemented in the next PR)

TBD
* need to determine if the `vendor_deps` rake task should be updated to support importing javascript files (or perhaps _only_ the javascript files we need) 

/domain @Betterment/test_track_core 
