### PR TITLE
Fix Heroku button

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,19 +1,20 @@
-rails_env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
-environment rails_env
+workers Integer(ENV['PUMA_WORKER_COUNT'] || ENV['WEB_CONCURRENCY'] || 2)
+thread_count = Integer(ENV['PUMA_THREAD_COUNT'] || ENV['RAILS_MAX_THREADS'] || 5)
+threads thread_count, thread_count
 
-if rails_env == 'development'
-  thread_count = Integer(ENV.fetch('PUMA_THREAD_COUNT', '5'))
-  threads thread_count, thread_count
+preload_app!
+
+rackup      DefaultRackup
+
+rails_env = ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
+
+if rails_env == 'development' || ENV['PORT']
   port ENV.fetch('PORT', '3000')
 else
-  worker_count = Integer(ENV.fetch('PUMA_WORKER_COUNT'))
-  workers worker_count
-  thread_count = Integer(ENV.fetch('PUMA_THREAD_COUNT'))
-  threads thread_count, thread_count
   bind 'unix:///var/run/puma/testtrack.sock'
 end
 
-preload_app!
+environment rails_env
 
 on_worker_boot do
   ActiveRecord::Base.establish_connection


### PR DESCRIPTION
### Summary

The Heroku button regressed because our puma.conf (which used to be ignored but seems to be used by Heroku now) is not aligned with a Heroku 12-factor app - it uses unconventional thread/worker variable names and binds to a unix socket instead of a TCP port. I made switching to TCP conditional on the presence of a PORT env var, which Heroku provides, and added fall-thru to the heroku conventional thread scaling variable names. In the process I swapped the ordering of the preload to be more conventional with Heroku's recommended config. I'm not sure whether this will cause trouble for our production setup at Betterment. We'll want to do a stage deploy after merge and possibly a follow-on patch if it doesn't deploy correctly in our env anymore.

### Other Information

Thanks @thestumonkey for reporting #38

/domain @Betterment/test_track_core