### PR TITLE
Properly includes variant details by way of the split presenter

### DIFF
--- a/app/models/split_detail.rb
+++ b/app/models/split_detail.rb
@@ -4,7 +4,7 @@ class SplitDetail
   include DelegateAttribute
 
   attr_accessor :split
-  delegate :name, :variant_details, to: :split
+  delegate :name, :variants, to: :split
   delegate_attribute :hypothesis, :assignment_criteria, :description, :owner, :location, :platform, to: :split
 
   validates :hypothesis, :assignment_criteria, :description, :owner, :location, :platform, presence: true
@@ -14,6 +14,12 @@ class SplitDetail
     raise 'A split is required to create split details' unless params[:split].present?
     self.split = params.delete(:split)
     super
+  end
+
+  def variant_details
+    @variant_details ||= variants.map do |variant|
+      VariantDetail.find_or_initialize_by(split: split, variant: variant)
+    end
   end
 
   def save

--- a/spec/requests/api/v1/split_details_spec.rb
+++ b/spec/requests/api/v1/split_details_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::SplitDetailsController, type: :request do
   describe 'GET /api/v1/split_details/:id' do
     let(:default_app) { FactoryGirl.create :app, name: "default_app", auth_secret: "6Sd6T7T6Q8hKcoo0t8CTzV0IdN1EEHqXB2Ig4raZsOf" }
-    let(:split_with_no_details) { FactoryGirl.create :split, name: "fantastic_split" }
+    let(:split_with_no_details) { FactoryGirl.create :split, registry: { hammer: 99, nail: 1 }, name: "fantastic_split" }
     let(:split_with_details) { FactoryGirl.create :split, registry: { enabled: 99, disabled: 1 }, name: "fantastic_split_with_information", platform: 'mobile', description: 'Greatest Split', assignment_criteria: "Must love problem solvers", hypothesis: 'Will solve all problems', location: 'Everywhere', owner: 'Me' } # rubocop:disable Metrics/LineLength
 
     let!(:variant_detail_a) do
@@ -40,7 +40,16 @@ RSpec.describe Api::V1::SplitDetailsController, type: :request do
         "platform" => nil,
         "description" => nil,
         "owner" => nil,
-        "variant_details" => []
+        "variant_details" => [
+          {
+            "name" => "hammer",
+            "description" => nil
+          },
+          {
+            "name" => "nail",
+            "description" => nil
+          }
+        ]
       )
     end
 


### PR DESCRIPTION
This fixes a bug where we were exposing an empty array of variant details that had not been updated with new display names and descriptions, and uses the `SplitPresenter` class to set the `variant_details` on the `SplitDetail` model. 

/domain @Betterment/test_track_core @dschaub 
