### PR TITLE
Increases visibility around retiring variants and deciding splits

### DIFF
--- a/app/views/admin/splits/_details.html.erb
+++ b/app/views/admin/splits/_details.html.erb
@@ -1,6 +1,7 @@
 <article class="InfoCard InfoCard--constrained sc-m-v--l">
-  <div class="InfoCard-titleContainer">
-    <h4>Test details</h4>
+  <div class="InfoCard-header">
+    <h4>Split Details</h4>
+    <%= link_to "Decide Split", new_admin_split_decision_path(@split), class: 'decide-split-link button' %>
   </div>
   <hr class="InfoCard-divider">
   <div class="InfoCard-description">
@@ -17,7 +18,7 @@
       <tr>
         <td>Status</td>
         <td class="u-status--<%= @split.finished? ? 'finished' : 'active' %>"><%= @split.finished? ? 'Finished' : 'Active' %><span class="sc-p--s">🏁</span></td>
-        <td><%= link_to "Edit", new_admin_split_decision_path(@split), class: 'decide-split-link' %></td>
+        <td>&nbsp;</td>
       </tr>
       <tr>
         <td>App</td>

--- a/app/views/admin/splits/_test_overview.html.erb
+++ b/app/views/admin/splits/_test_overview.html.erb
@@ -1,6 +1,6 @@
-<article class="InfoCard TestOverview sc-m-v--l">
+<article class="InfoCard fs-SplitOverview sc-m-v--l">
   <div class="InfoCard-header">
-    <h4>Test Overview</h4>
+    <h4>Split Overview</h4>
 
     <% if split.has_details? %>
       <%= link_to "Edit", edit_admin_split_details_path(split), class: 'edit-details-link' %>
@@ -40,7 +40,7 @@
   <% else %>
     <div class="EmptyTable EmptyTable--centered sc-p--l">
       <p>
-        <strong>Add metadata to your test</strong>
+        <strong>Is this split a test? Add metadata about it.</strong>
         <br>
         This information is used to explain the context of what a user is experiencing.
       </p>

--- a/app/views/admin/splits/_variants.html.erb
+++ b/app/views/admin/splits/_variants.html.erb
@@ -17,17 +17,7 @@
           <tr>
             <td><%= variant_detail.display_name %></td>
             <td><%= variant_detail.description %></td>
-            <td><%= variant_detail.weight %>%(<%= variant_detail.assignment_count %>)
-              <% if variant_detail.retirable? %>
-              (<%= link_to "Retire variant", admin_split_variant_retirement_path(split, variant_detail.variant),
-                class: "retire-variant-link",
-                        method: :post,
-                        data: { confirm: <<-EOF } %>)
-                          You're redistributing #{variant_detail.variant} assignees to the other variants according to their weights.
-                          Do you wish to proceed?
-                        EOF
-              <% end %>
-            </td>
+            <td><%= variant_detail.weight %>%(<%= variant_detail.assignment_count %>)</td>
             <td><%= link_to 'edit', edit_admin_split_variant_detail_path(split, variant_detail.variant) %></td>
           </tr>
         <% end %>

--- a/app/views/admin/variant_details/edit.html.erb
+++ b/app/views/admin/variant_details/edit.html.erb
@@ -20,9 +20,7 @@
       <% if @variant_detail.retirable? %>
         <%= link_to "Retire variant", admin_split_variant_retirement_path(@split, @variant_detail.variant), class: "retire-variant-link button secondary",
           method: :post,
-          data: { confirm: <<-EOF } %>
-          You're redistributing #{@variant_detail.variant} assignees to the other variants according to their weights. Do you wish to proceed?
-          EOF
+          data: { confirm: "You're redistributing #{@variant_detail.variant} assignees to the other variants according to their weights. Do you wish to proceed?" } %>
       <% end %>
       <%= f.submit 'Continue', data: { disable_with: 'Updating variant...' }, class: 'u-button ft-confirmButton' %>
     </div>

--- a/app/views/admin/variant_details/edit.html.erb
+++ b/app/views/admin/variant_details/edit.html.erb
@@ -17,6 +17,13 @@
   <div class="sc-TakeoverFooter">
     <div class="sc-TakeoverFooter-content">
       <%= link_to 'Back', admin_split_path(@split), class: 'sc-TakeoverFooter-ctaBack sc-Link sc-Link--arrowLeft ft-backButton' %>
+      <% if @variant_detail.retirable? %>
+        <%= link_to "Retire variant", admin_split_variant_retirement_path(@split, @variant_detail.variant), class: "retire-variant-link button secondary",
+          method: :post,
+          data: { confirm: <<-EOF } %>
+          You're redistributing #{@variant_detail.variant} assignees to the other variants according to their weights. Do you wish to proceed?
+          EOF
+      <% end %>
       <%= f.submit 'Continue', data: { disable_with: 'Updating variant...' }, class: 'u-button ft-confirmButton' %>
     </div>
   </div>

--- a/spec/features/admin_split_details_create_spec.rb
+++ b/spec/features/admin_split_details_create_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'admin can add details to a split' do
   it 'allows admins to add details to a split' do
     split_page.load split_id: split.id
     expect(split_page).to be_displayed
-    expect(split_page.test_overview).to have_content "Add metadata to your test"
+    expect(split_page.test_overview).to have_content "Is this split a test? Add metadata about it."
 
     split_page.add_details.click
     expect(split_details_page).to be_displayed

--- a/spec/features/admin_variant_details_edit_spec.rb
+++ b/spec/features/admin_variant_details_edit_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe 'admin can edit variant details' do
   let(:split_page) { app.admin_split_show_page }
   let(:variant_page) { app.admin_variant_details_edit_page }
 
-  let!(:split) { FactoryGirl.create(:split, name: 'great_feature', registry: { enabled: 100 }) }
+  let!(:split) { FactoryGirl.create(:split, name: 'great_feature', registry: { enabled: 100, disabled: 0 }) }
+  let(:variant_to_retire) { :disabled }
 
   let(:variant_screenshot) { Rails.root.join('spec/support/uploads/ttlogo.png') }
 
   before do
+    FactoryGirl.create_list(:assignment, 2, split: split, variant: variant_to_retire)
     login
   end
 
@@ -16,10 +18,11 @@ RSpec.describe 'admin can edit variant details' do
     split_page.load split_id: split.id
     expect(split_page).to be_displayed
 
-    expect(split_page.variants.count).to eq 1
-    split_page.variants.first.edit_link.click
+    expect(split_page.variants.count).to eq 2
 
+    split_page.edit_variant(:enabled)
     expect(variant_page).to be_displayed
+    expect(variant_page).not_to have_content "Retire variant"
 
     variant_page.form.display_name.set 'Variant name'
     variant_page.form.description.set 'Super great variant'
@@ -33,5 +36,16 @@ RSpec.describe 'admin can edit variant details' do
 
     split_page.variants.first.edit_link.click
     expect(variant_page.form.current_screenshot).to have_content 'ttlogo.png'
+  end
+
+  context 'when a split variant can be retired' do
+    it 'allows admins to retire variant details' do
+      split_page.load split_id: split.id
+
+      split_page.edit_variant(variant_to_retire)
+
+      expect(variant_page).to be_displayed
+      expect(variant_page).to have_content "Retire variant"
+    end
   end
 end

--- a/spec/features/admin_variant_retirement_create_spec.rb
+++ b/spec/features/admin_variant_retirement_create_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'admin can retire a variant for a split' do
     expect(split_page.variants_table).to have_content "blue 0%(0)"
 
     split_page.edit_variant("blue")
-    expect(split_page.variants_table).not_to have_content "Retire variant"
+    expect(variant_page).to be_displayed
+    expect(variant_page).not_to have_content "Retire variant"
   end
 end

--- a/spec/features/admin_variant_retirement_create_spec.rb
+++ b/spec/features/admin_variant_retirement_create_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'admin can retire a variant for a split' do
   let(:split_page) { app.admin_split_show_page }
-
+  let(:variant_page) { app.admin_variant_details_edit_page }
   let!(:split) { FactoryGirl.create :split, registry: { red: 25, blue: 0, green: 25, yellow: 25, orange: 25 } }
 
   before do
@@ -17,11 +17,21 @@ RSpec.describe 'admin can retire a variant for a split' do
   it 'allows admins to retire a variant' do
     split_page.load split_id: split.id
     expect(split_page).to be_displayed
-    expect(split_page.variants_table).to have_content "blue 0%(8) (Retire variant)"
+    expect(split_page.variants_table).to have_content "blue 0%(8)"
 
-    split_page.retire_variant.click
+    split_page.edit_variant("blue")
+    expect(variant_page).to be_displayed
+    expect(variant_page).to have_content "Retire variant"
 
+    variant_page.accept_confirm do
+      variant_page.retire_variant
+    end
+
+    expect(split_page).to be_displayed
+    expect(split_page).to have_content "Retired blue"
     expect(split_page.variants_table).to have_content "blue 0%(0)"
+
+    split_page.edit_variant("blue")
     expect(split_page.variants_table).not_to have_content "Retire variant"
   end
 end

--- a/spec/support/pages/admin/split_show_page.rb
+++ b/spec/support/pages/admin/split_show_page.rb
@@ -4,12 +4,11 @@ class AdminSplitShowPage < SitePrism::Page
   element :population_count, "tr.population-row span.population"
 
   element :change_weights, ".change-weights-link"
-  element :retire_variant, ".retire-variant-link"
   element :add_details, ".add-details-link"
   element :decide_split, ".decide-split-link"
   element :upload_new_assignments, ".upload-new-assignments-link"
 
-  section :test_overview, ".TestOverview" do
+  section :test_overview, ".fs-SplitOverview" do
     element :table, ".DescriptionTable"
   end
 
@@ -19,5 +18,8 @@ class AdminSplitShowPage < SitePrism::Page
     element :description, 'td:nth-of-type(2)'
     element :weight, 'td:nth-of-type(3)'
     element :edit_link, 'td:nth-of-type(4) a'
+  end
+  def edit_variant(text)
+    variants_table.find('tr', text: text).find('a').click
   end
 end

--- a/spec/support/pages/admin/variant_details_edit_page.rb
+++ b/spec/support/pages/admin/variant_details_edit_page.rb
@@ -6,6 +6,11 @@ class AdminVariantDetailsEditPage < SitePrism::Page
     element :description, 'textarea[name="variant_detail[description]"]'
     element :screenshot, 'input[name="variant_detail[screenshot]"]'
     element :current_screenshot, '.variant_detail_screenshot .hint'
+    element :retire_button, '.retire-variant-link'
     element :submit_button, 'input[type=submit]'
+  end
+
+  def retire_variant
+    form.retire_button.click
   end
 end


### PR DESCRIPTION
* Moves "Decide split" link to a button in the "Split Details" module on the split page
* Modifies language on split show page to emphasize SPLIT over TEST
* Updates tests

![test_track_updates](https://cloud.githubusercontent.com/assets/3853922/25815995/a672c58c-33f0-11e7-941c-754e58cabec1.gif)

/domain @Betterment/test_track_core @jmileham @samandmoore 
