### PR TITLE
Less config needed when you use the rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'database_cleaner'
 
-  gem 'factory_bot'
+  gem 'factory_bot_rails'
 
   gem 'ruby_spec_helpers', path: 'vendor/gems/ruby_spec_helpers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,9 @@ GEM
     execjs (2.7.0)
     factory_bot (4.8.2)
       activesupport (>= 3.0.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
+      railties (>= 3.0.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
@@ -394,7 +397,7 @@ DEPENDENCIES
   delayed_job_active_record
   devise (>= 3.5.4, < 4)
   dotenv-rails
-  factory_bot
+  factory_bot_rails
   foreman
   jbuilder (~> 2.0)
   jquery-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,11 +60,3 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
-
-RSpec.configure do |config|
-  config.include FactoryBot::Syntax::Methods
-
-  config.before(:suite) do
-    FactoryBot.find_definitions
-  end
-end


### PR DESCRIPTION
### Summary

In my haste to get all the upgrades working, I included the bare `factory_bot` gem which required more config than `factory_bot_rails` does. So I fixed it.

/domain @aburgel 
/no-platform