### PR TITLE
Ditch logentries gem, explicitly log to STDOUT in prod/stage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,6 @@ gem 'rack-timeout'
 
 gem 'airbrake', '~> 4.3.2'
 
-gem 'le'
-
 gem 'newrelic_rpm'
 
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,6 @@ GEM
     json (1.8.6)
     launchy (2.4.3)
       addressable (~> 2.3)
-    le (2.7.5)
     libv8 (3.16.14.19)
     loofah (2.1.1)
       crass (~> 1.0.2)
@@ -403,7 +402,6 @@ DEPENDENCIES
   foreman
   jbuilder (~> 2.0)
   jquery-rails
-  le
   newrelic_rpm
   nokogiri
   omniauth-saml

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -71,5 +71,6 @@ Rails.application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  config.logger = ActiveSupport::TaggedLogging.new(Le.new(ENV['LOGENTRIES_TOKEN'])) if ENV['LOGENTRIES_TOKEN'].present?
+  # Use a different logger for distributed setups.
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
 end

--- a/config/environments/labs.rb
+++ b/config/environments/labs.rb
@@ -71,5 +71,6 @@ Rails.application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  config.logger = ActiveSupport::TaggedLogging.new(Le.new(ENV['LOGENTRIES_TOKEN'])) if ENV['LOGENTRIES_TOKEN'].present?
+  # Use a different logger for distributed setups.
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,9 +51,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -77,5 +74,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.logger = ActiveSupport::TaggedLogging.new(Le.new(ENV['LOGENTRIES_TOKEN'])) if ENV['LOGENTRIES_TOKEN'].present?
+  # Use a different logger for distributed setups.
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
 end

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -71,5 +71,6 @@ Rails.application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  config.logger = ActiveSupport::TaggedLogging.new(Le.new(ENV['LOGENTRIES_TOKEN'])) if ENV['LOGENTRIES_TOKEN'].present?
+  # Use a different logger for distributed setups.
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
 end


### PR DESCRIPTION
### Summary

I think the Rails 5 stuff broke some logging. This is an attempt to fix that, but we should confirm in stage that this is the correct solution.

Also this resolves #18 - we don't need the gem dependency.

/domain @Betterment/test_track_core 
/platform @jmileham @aburgel @samandmoore 
