### PR TITLE
Fix semantic logger with puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -18,4 +18,5 @@ environment rails_env
 
 on_worker_boot do
   ActiveRecord::Base.establish_connection
+  SemanticLogger.reopen if defined?(SemanticLogger)
 end


### PR DESCRIPTION
/domain @Betterment/test_track_core @agirlnamedsophia 
/no-platform

Forgot that we need to add a bit of config for Semantic Logger to work with Puma: https://rocketjob.github.io/semantic_logger/forking.html#puma

The `if defined?` conditional ensures that we don't depend on the library if its not enabled.