### PR TITLE
address race condition in visitor supersession

### DIFF
--- a/app/models/visitor_supersession.rb
+++ b/app/models/visitor_supersession.rb
@@ -24,7 +24,7 @@ class VisitorSupersession < ActiveRecord::Base
     end
   rescue ActiveRecord::RecordNotUnique, PG::UniqueViolation # rubocop:disable Lint/HandleExceptions
     # the goal here is to make sure that any splits that the old visitor had
-    # that the new visitor doesn't have are carried over to the new visitor.
+    # (that the new visitor doesn't have) are carried over to the new visitor.
     # so, if there is a conflict here, we can safely ignore it.
   end
 end

--- a/app/models/visitor_supersession.rb
+++ b/app/models/visitor_supersession.rb
@@ -23,7 +23,8 @@ class VisitorSupersession < ActiveRecord::Base
       )
     end
   rescue ActiveRecord::RecordNotUnique, PG::UniqueViolation # rubocop:disable Lint/HandleExceptions
-    # ignore or find
-    # we're not using the result, so probably just ignore
+    # the goal here is to make sure that any splits that the old visitor had
+    # that the new visitor doesn't have are carried over to the new visitor.
+    # so, if there is a conflict here, we can safely ignore it.
   end
 end

--- a/app/models/visitor_supersession.rb
+++ b/app/models/visitor_supersession.rb
@@ -6,15 +6,24 @@ class VisitorSupersession < ActiveRecord::Base
 
   private
 
-  def merge_assignments! # rubocop:disable Metrics/AbcSize
+  def merge_assignments!
     target_split_ids = superseding_visitor.assignments.map(&:split_id).to_set
-    superseded_visitor.assignments.order(:id).map do |a|
+    superseded_visitor.assignments.order(:id).each do |a|
+      create_or_ignore_duplicate(a) unless target_split_ids.include?(a.split_id)
+    end
+  end
+
+  def create_or_ignore_duplicate(assignment)
+    transaction(requires_new: true) do
       superseding_visitor.assignments.create!(
-        variant: a.variant,
-        split_id: a.split_id,
+        variant: assignment.variant,
+        split_id: assignment.split_id,
         context: 'visitor_supersession',
         visitor_supersession: self
-      ) unless target_split_ids.include?(a.split_id)
+      )
     end
+  rescue ActiveRecord::RecordNotUnique, PG::UniqueViolation # rubocop:disable Lint/HandleExceptions
+    # ignore or find
+    # we're not using the result, so probably just ignore
   end
 end


### PR DESCRIPTION
### Summary

we occasionally see two supersessions occur concurrently for the same
visitor. one of those will succeed and the other will fail. this results
in the loss of the supersession history. this is not really a huge deal,
but the annoying thing is that this results in an inactionable error.

the solution in this changeset is to use savepoints and rescuing to
swallow the unique violations.

/domain @Betterment/test_track_core 
/platform @jmileham @aburgel 

Does anyone know if i definitely do or do not have to capture the `PG::UniqueViolation`? I believe that Rails will wrap that in `ActiveRecord::RecordNotUnique`, but it's hard to reproduce this exact case locally.