### PR TITLE
don't log rack-timeout things except errors, cut down max service time

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,11 @@
-Rack::Timeout.timeout = 120 # seconds
+Rack::Timeout.service_timeout = 30
+
+if Rails.env.development? || Rails.env.test?
+  Rack::Timeout::Logger.disable
+else
+  # have to clone the logger b/c https://github.com/heroku/rack-timeout/issues/104
+  Rails.logger.clone.tap do |l|
+    l.level = ::Logger::ERROR
+    Rack::Timeout::Logger.logger = l
+  end
+end


### PR DESCRIPTION
### Summary

It's generally a good thing to set tighter timeouts on your endpoints. This changes the timeout from 2 minutes to 30 seconds. We occasionally see 30ish second requests loading splits with large #s of assignments the first time. All that time is spent in PG. Until we come up with a solution to that, we're going to cap our timeout at 30 seconds. We used to need it to be even longer because we had a bunch of admin features that didn't run in the background, but all but one of those (variant retirement) is backgrounded now. Since we don't use that feature very often, we're prioritizing this change over backgrounding that feature.

### Other Information

We're also changing it so that logging for rack-timeout only occurs in production environments and only at the ERROR log level. rack-timeout logs too much otherwise.

> Thanks for contributing to TestTrack!

/domain @Betterment/test_track_core 