### PR TITLE
Semantic Logger improvements

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,8 @@ module TestTrack
     if ENV["SEMANTIC_LOGGER_ENABLED"].present?
       require 'rails_semantic_logger'
 
+      SemanticLogger.application = Rails.application.class.parent_name
+
       config.rails_semantic_logger.add_file_appender = false
       config.semantic_logger.add_appender(io: $stdout, formatter: :json)
     end

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -71,6 +71,7 @@ Rails.application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  # Use a different logger for distributed setups.
-  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  if ENV["SEMANTIC_LOGGER_ENABLED"].blank?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
 end
 
 ENV['WHITELIST_CORS_HOSTS'] ||= %w(.dev).join(',')

--- a/config/environments/labs.rb
+++ b/config/environments/labs.rb
@@ -71,6 +71,7 @@ Rails.application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  # Use a different logger for distributed setups.
-  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  if ENV["SEMANTIC_LOGGER_ENABLED"].blank?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,6 +74,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Use a different logger for distributed setups.
-  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  if ENV["SEMANTIC_LOGGER_ENABLED"].blank?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
 end

--- a/config/environments/stage.rb
+++ b/config/environments/stage.rb
@@ -71,6 +71,7 @@ Rails.application.configure do
   # Set to :debug to see everything in the log.
   config.log_level = :info
 
-  # Use a different logger for distributed setups.
-  config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  if ENV["SEMANTIC_LOGGER_ENABLED"].blank?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
 end


### PR DESCRIPTION
### Summary

1. Propogate conditional usage of taggedLogger based on semantic logger env var. This didn't cause actual symptoms because it was overwritten later, but I think this clarifies the intent.

2. Use the app name to avoid the current default of 'Semantic Logger'

/domain @Betterment/test_track_core @samandmoore
