### PR TITLE
Make name validation errors be more informative

### DIFF
--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -80,11 +80,11 @@ class Split < ActiveRecord::Base
   end
 
   def name_must_not_include_new
-    errors[:name] << "'new' is too vague. Use absolute time if needed e.g. 'summary_redesign_late_2015'" if name_contains_new?
+    errors[:name] << "should not contain the ambiguous word 'new'. If expressing timing, refer to absolute time like 'late_2015'. If expressing creation use 'create'." if name_contains_new?
   end
 
   def name_must_not_end_with_test
-    errors[:name] << "'test' is redundant.  All splits are testable." if name_ends_with_test?
+    errors[:name] << "should not end with 'test', as it is redundant. All splits are testable." if name_ends_with_test?
   end
 
   def variants_must_be_snake_case


### PR DESCRIPTION
### Summary

The current name validations output somewhat ambiguous and vague error messages. In my opinion, it is not clear what the error message refers to as it reads as though the name is being interpreted as 'new'. It was only until I dove into the code did I realize it referred to the fact that the name cannot contain the term 'new'. For example:

```
Name 'new' is too vague. Use absolute time if needed e.g. 'summary_redesign_late_2015'
```

Updating the validation errors to be less ambiguous and provide clearer direction on why the name is not valid in a more human readable format.

/domain @Betterment/test_track_core @jmileham 
/no-platform
