### PR TITLE
update database cleaner to 1.7.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
-    database_cleaner (1.6.2)
+    database_cleaner (1.7.0)
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
       rspec (~> 3.0)


### PR DESCRIPTION
### Summary

Updating database cleaner ahead of upgrading this app to rails 5.1. This is due to a deprecation warning that is accounted for in newer versions of database cleaner [here](https://github.com/DatabaseCleaner/database_cleaner/blob/master/lib/database_cleaner/active_record/truncation.rb#L30).

/domain @betterzega @samandmoore 
/no-platform