### PR TITLE
Upgrade Devise to 4.4.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     aws-sdk-resources (2.3.22)
       aws-sdk-core (= 2.3.22)
     backports (3.10.3)
-    bcrypt (3.1.11)
+    bcrypt (3.1.12)
     binding_of_caller (0.7.3)
       debug_inspector (>= 0.0.1)
     bourbon (4.2.0)
@@ -114,10 +114,10 @@ GEM
     delayed_job_active_record (4.1.2)
       activerecord (>= 3.0, < 5.2)
       delayed_job (>= 3.0, < 5)
-    devise (4.3.0)
+    devise (4.4.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.2)
+      railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -451,4 +451,4 @@ DEPENDENCIES
   with_transactional_lock
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
### Summary

Upgrade Devise to version `4.4.3`

This is done to pave the way to Rails 5.3 which is supported by Devise 4.4.

Devise Changelog: https://github.com/plataformatec/devise/blob/master/CHANGELOG.md#443---2018-03-17
Devise Diff from old version: https://github.com/plataformatec/devise/compare/v4.3.0...v4.4.3


/domain @samandmoore @betterzega 
/platform @samandmoore @betterzega 
