### PR TITLE
Upgrade to patched sprockets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,7 +340,7 @@ GEM
       addressable (>= 2.3.3, < 3.0)
       capybara (>= 2.1, < 3.0)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
### Summary

Patch in response to CVE-2018-3760. We do not compile assets in production so the TestTrack app is not vulnerable by default, but best to put this vulnerable version of sprockets in the rearview anyway.

/domain @Betterment/test_track_core @samandmoore @aburgel 