### PR TITLE
Adds ddtrace gem and configures DataDog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'rack-timeout'
 gem 'airbrake', '~> 7.3.5'
 
 gem 'newrelic_rpm'
+gem 'ddtrace'
 
 gem 'rails_semantic_logger', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,9 @@ GEM
     db-query-matchers (0.9.0)
       activesupport (>= 4.0, <= 6.0)
       rspec (~> 3.0)
+    ddtrace (0.17.2)
+      msgpack
+      opentracing (>= 0.4.1)
     debug_inspector (0.0.3)
     delayed_job (4.1.3)
       activesupport (>= 3.0, < 5.2)
@@ -181,6 +184,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    msgpack (1.2.4)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     neat (1.7.2)
@@ -198,6 +202,7 @@ GEM
     omniauth-saml (1.8.1)
       omniauth (~> 1.3)
       ruby-saml (~> 1.4, >= 1.4.3)
+    opentracing (0.4.3)
     orm_adapter (0.5.0)
     paperclip (5.3.0)
       activemodel (>= 4.2.0)
@@ -409,6 +414,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2.0)
   database_cleaner
   db-query-matchers
+  ddtrace
   delayed_job
   delayed_job_active_record
   devise
@@ -450,4 +456,4 @@ DEPENDENCIES
   with_transactional_lock
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,12 @@
+require 'ddtrace'
+
+unless Rails.env.in?(%w(development test))
+  service_name = Rails.application.class.parent_name.underscore
+
+  Datadog.configure do |c|
+    c.use :rails, service_name: service_name, distributed_tracing: true
+    c.use :active_record, orm_service_name: "#{service_name}-active_record"
+    c.use :delayed_job, service_name: "#{service_name}-delayed_job"
+    c.use :http, service_name: "#{service_name}-http", distributed_tracing: true
+  end
+end

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,12 +1,14 @@
-require 'ddtrace'
+if ENV['DATADOG_ENABLED']
+  require 'ddtrace'
 
-unless Rails.env.in?(%w(development test))
-  service_name = Rails.application.class.parent_name.underscore
+  unless Rails.env.in?(%w(development test))
+    service_name = Rails.application.class.parent_name.underscore
 
-  Datadog.configure do |c|
-    c.use :rails, service_name: service_name, distributed_tracing: true
-    c.use :active_record, orm_service_name: "#{service_name}-active_record"
-    c.use :delayed_job, service_name: "#{service_name}-delayed_job"
-    c.use :http, service_name: "#{service_name}-http", distributed_tracing: true
+    Datadog.configure do |c|
+      c.use :rails, service_name: service_name, distributed_tracing: true
+      c.use :active_record, orm_service_name: "#{service_name}-active_record"
+      c.use :delayed_job, service_name: "#{service_name}-delayed_job"
+      c.use :http, service_name: "#{service_name}-http", distributed_tracing: true
+    end
   end
 end


### PR DESCRIPTION
### Summary

This adds support for a DataDog integration. It configures the default process names as well so that they will come through as `test_track`, `test_track-http`, `test_track-active-record`, and `test_track-delayed_job`. 

Datadog will only be configured if the environment variable `DATADOG_ENABLED` is set to `true`.

/domain @Betterment/test_track_core 
/platform @jmileham @samandmoore 