### PR TITLE
Clean out finished_at in create

### DIFF
--- a/app/models/split_creation.rb
+++ b/app/models/split_creation.rb
@@ -7,6 +7,7 @@ class SplitCreation
   validate :split_must_be_valid
 
   def save
+    split.finished_at = nil
     split.reassign_weight(merged_registry) unless split.registry == merged_registry
     return false unless valid?
     split.save

--- a/spec/models/split_creation_spec.rb
+++ b/spec/models/split_creation_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe SplitCreation do
     expect(weather.registry.symbolize_keys).to eq rain: 0, snow: 0, clear_skies: 100, hurricane: 0
   end
 
+  it 'reenables a finished split' do
+    bad_weather_create.save
+    Split.find_by!(name: "weather").update(finished_at: Time.zone.now)
+    good_weather_create.save
+
+    weather = Split.find_by(name: "weather")
+    expect(weather.finished_at).to be_nil
+  end
+
   it 'delegates validation errors to split' do
     split_creation = SplitCreation.new(app: default_app, name: "bad_test", weighting_registry: { badBadBad: 100 })
     expect(split_creation.save).to eq false

--- a/spec/models/split_creation_spec.rb
+++ b/spec/models/split_creation_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SplitCreation do
 
   it 'reenables a finished split' do
     bad_weather_create.save
-    Split.find_by!(name: "weather").update(finished_at: Time.zone.now)
+    Split.find_by!(name: "weather").update!(finished_at: Time.zone.now)
     good_weather_create.save
 
     weather = Split.find_by(name: "weather")


### PR DESCRIPTION
### Summary

If you want to reenable a finished split via a migration, it won't actually un-finish it. This fixes that.

/domain @Betterment/test_track_core 
/no-platform