### PR TITLE
set "Vary": "Origin" header

### DIFF
--- a/app/controllers/concerns/cors_support.rb
+++ b/app/controllers/concerns/cors_support.rb
@@ -48,5 +48,6 @@ module CorsSupport
   def add_common_cors_headers
     headers['Access-Control-Allow-Origin'] = origin
     headers['Access-Control-Allow-Credentials'] = 'true'
+    headers['Vary'] = 'Origin'
   end
 end


### PR DESCRIPTION
### Summary

We use Test Track on a few domains: example.org and sub.example.org. At example.org we have a link that redirects a user to sub.example.org. When the user lands onto sub.example.org and clicks back in Chrome Browser, it causes the CORS error at example.org, because the request to Test Track server has been cached with `Origin: sub.example.org`. I hope this link will explain what happens.

https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches


/domain @Betterment/test_track_core 
