### PR TITLE
Knockout incomplete feature weightings

### DIFF
--- a/app/controllers/api/v1/split_registries_controller.rb
+++ b/app/controllers/api/v1/split_registries_controller.rb
@@ -2,6 +2,6 @@ class Api::V1::SplitRegistriesController < UnauthenticatedApiController
   include CorsSupport
 
   def show
-    @active_splits = Split.active
+    @active_splits = Split.for_presentation
   end
 end

--- a/app/models/app_feature_completion.rb
+++ b/app/models/app_feature_completion.rb
@@ -7,11 +7,13 @@ class AppFeatureCompletion < ActiveRecord::Base
   validates :app, :split, :version, presence: true
   validates :split, uniqueness: { scope: :app }
 
-  # This scope requires you to BYO `splits` FROM clause
+  # This scope requires you to BYO `splits` FROM clause either via join or an
+  # outer scope, if using this as a subselect.
   scope :satisfied_by, ->(app_build) do
-    where('split_id = splits.id')
-      .where(<<~SQL, app_id: app_build.app_id, version: app_build.version.to_pg_array)
-        app_id = :app_id and app_feature_completions.version <= :version
-      SQL
+    where(
+      arel_table[:split_id].eq(Split.arel_table[:id])
+      .and(arel_table[:app_id].eq(app_build.app_id))
+      .and(arel_table[:version].lteq(app_build.version))
+    )
   end
 end

--- a/app/models/app_feature_completion.rb
+++ b/app/models/app_feature_completion.rb
@@ -6,4 +6,12 @@ class AppFeatureCompletion < ActiveRecord::Base
 
   validates :app, :split, :version, presence: true
   validates :split, uniqueness: { scope: :app }
+
+  # This scope requires you to BYO `splits` FROM clause
+  scope :satisfied_by, ->(app_build) do
+    where('split_id = splits.id')
+      .where(<<~SQL, app_id: app_build.app_id, version: app_build.version.to_pg_array)
+        app_id = :app_id and app_feature_completions.version <= :version
+      SQL
+  end
 end

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -131,10 +131,10 @@ class Split < ActiveRecord::Base
 
   def knock_out_weightings(registry_hash, to: "false")
     target_variant = to.to_s
-    knock_out_hash(registry_hash, to: target_variant) || log_knockout_error(target_variant) && registry_hash
+    knock_out_weightings_if_possible(registry_hash, to: target_variant) || log_knockout_error(target_variant) && registry_hash
   end
 
-  def knock_out_hash(registry_hash, to:)
+  def knock_out_weightings_if_possible(registry_hash, to:)
     found_key = false
     knocked_out_registry = registry_hash.each_with_object({}) do |(k, _), h|
       h[k] = (k.to_s == to ? (found_key = true && 100) : 0)

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -120,7 +120,7 @@ class Split < ActiveRecord::Base
   end
 
   def registry
-    if try(:feature_incomplete?)
+    if try(:feature_incomplete?) # This is a virtual attribute provided by the with_feature_incomplete_knockouts_for scope
       knock_out_weightings(super)
     else
       super

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -27,7 +27,7 @@ class Split < ActiveRecord::Base
 
   scope :for_app_build, ->(app_build) do
     active(as_of: app_build.built_at)
-      .with_feature_completeness(app_build)
+      .with_feature_incomplete_knockouts_for(app_build)
   end
 
   scope :active, ->(as_of: nil) do

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -132,7 +132,7 @@ class Split < ActiveRecord::Base
   def knock_out_weightings(registry_hash, to: "false")
     found_key = false
     knocked_out_registry = registry_hash.each_with_object({}) do |(k, _), h|
-      h[k] = (k.to_s == to ? (found_key = true && 100) : 0)
+      h[k] = (k.to_s == to.to_s ? (found_key = true && 100) : 0)
     end
     if found_key
       knocked_out_registry

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -40,7 +40,7 @@ class Split < ActiveRecord::Base
       .select(
         previous_selects,
         Arel::SelectManager.new
-      .where(arel_excluding_incomplete_features_for(app_build).not)
+          .where(arel_excluding_incomplete_features_for(app_build).not)
           .exists
           .as('feature_incomplete')
       )

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -131,8 +131,9 @@ class Split < ActiveRecord::Base
 
   def knock_out_weightings(registry_hash, to: "false")
     found_key = false
+    to = to.to_s
     knocked_out_registry = registry_hash.each_with_object({}) do |(k, _), h|
-      h[k] = (k.to_s == to.to_s ? (found_key = true && 100) : 0)
+      h[k] = (k.to_s == to ? (found_key = true && 100) : 0)
     end
     if found_key
       knocked_out_registry

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -130,17 +130,21 @@ class Split < ActiveRecord::Base
   private
 
   def knock_out_weightings(registry_hash, to: "false")
+    target_variant = to.to_s
+    knock_out_hash(registry_hash, to: target_variant) || log_knockout_error(target_variant) && registry_hash
+  end
+
+  def knock_out_hash(registry_hash, to:)
     found_key = false
-    to = to.to_s
     knocked_out_registry = registry_hash.each_with_object({}) do |(k, _), h|
       h[k] = (k.to_s == to ? (found_key = true && 100) : 0)
     end
-    if found_key
-      knocked_out_registry
-    else
-      logger.error "Failed to knock out weightings of split #{name.inspect} because variant #{to.inspect} not found."
-      registry_hash
-    end
+    found_key ? knocked_out_registry : nil
+  end
+
+  def log_knockout_error(to)
+    logger.error "Failed to knock out weightings of split #{name.inspect} because variant #{to.inspect} not found."
+    true
   end
 
   def name_must_be_snake_case

--- a/app/models/split_registry.rb
+++ b/app/models/split_registry.rb
@@ -2,7 +2,7 @@ class SplitRegistry
   include Singleton
 
   def splits
-    Split.active
+    Split.for_presentation
   end
 
   def experience_sampling_weight

--- a/spec/models/app_feature_completion_spec.rb
+++ b/spec/models/app_feature_completion_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe AppFeatureCompletion do
       expect(described_class.joins(:split).satisfied_by(app_build)).to include(fc)
     end
 
+    it "returns a record for an app_build with a greater version" do
+      fc = FactoryBot.create(:app_feature_completion, app: app, split: split, version: "0.9")
+
+      expect(described_class.joins(:split).satisfied_by(app_build)).to include(fc)
+    end
+
     it "doesn't return a record for an app_build with a lower version" do
       fc = FactoryBot.create(:app_feature_completion, app: app, split: split, version: "1.1")
 

--- a/spec/models/app_feature_completion_spec.rb
+++ b/spec/models/app_feature_completion_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe AppFeatureCompletion do
+  describe ".satisfied_by" do
+    let(:split) { FactoryBot.create(:split) }
+    let(:app) { FactoryBot.create(:app) }
+    let(:app_build) { app.define_build(built_at: Time.zone.now, version: "1.0") }
+    let(:different_app) { FactoryBot.create(:app) }
+
+    it "blows up if you don't BYO splits table" do
+      FactoryBot.create(:app_feature_completion, app: app, split: split, version: "1.0")
+
+      expect { described_class.satisfied_by(app_build).to_a }.to raise_error(/missing FROM-clause entry for table "splits"/)
+    end
+
+    it "returns a record for an app_build with the same app_id and version" do
+      fc = FactoryBot.create(:app_feature_completion, app: app, split: split, version: "1.0")
+
+      expect(described_class.joins(:split).satisfied_by(app_build)).to include(fc)
+    end
+
+    it "doesn't return a record for an app_build with a lower version" do
+      fc = FactoryBot.create(:app_feature_completion, app: app, split: split, version: "1.1")
+
+      expect(described_class.joins(:split).satisfied_by(app_build)).not_to include(fc)
+    end
+
+    it "doesn't return a record for an app build for a different app" do
+      fc = FactoryBot.create(:app_feature_completion, app: different_app, split: split, version: "1.0")
+
+      expect(described_class.joins(:split).satisfied_by(app_build)).not_to include(fc)
+    end
+  end
+end

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -209,29 +209,29 @@ RSpec.describe Split, type: :model do
     end
   end
 
-  describe ".with_feature_completeness" do
+  describe ".with_feature_completeness_for" do
     let(:app) { FactoryBot.create(:app) }
     let(:app_build) { app.define_build(built_at: Time.zone.now, version: "1.0") }
 
     it "is feature_complete for non-feature gates" do
       split = FactoryBot.create(:split, feature_gate: false)
-      expect(Split.with_feature_completeness(app_build).find(split.id)).to be_feature_complete
+      expect(Split.with_feature_completeness_for(app_build).find(split.id)).to be_feature_complete
     end
 
     it "returns readonly records" do
       split = FactoryBot.create(:split, feature_gate: false)
-      expect(Split.with_feature_completeness(app_build).find(split.id)).to be_readonly
+      expect(Split.with_feature_completeness_for(app_build).find(split.id)).to be_readonly
     end
 
     it "returns false for feature gates with no feature completion" do
       split = FactoryBot.create(:split, feature_gate: true)
-      expect(Split.with_feature_completeness(app_build).find(split.id)).not_to be_feature_complete
+      expect(Split.with_feature_completeness_for(app_build).find(split.id)).not_to be_feature_complete
     end
 
     it "returns true for feature gates with a feature completion" do
       split = FactoryBot.create(:split, feature_gate: true)
       FactoryBot.create(:app_feature_completion, app: app, version: "1.0", split: split)
-      expect(Split.with_feature_completeness(app_build).find(split.id)).to be_feature_complete
+      expect(Split.with_feature_completeness_for(app_build).find(split.id)).to be_feature_complete
     end
   end
 end

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -307,4 +307,46 @@ RSpec.describe Split, type: :model do
       expect(subject_with_knockouts.registry).to eq("true" => 50, "false" => 50)
     end
   end
+
+  describe ".for_presentation" do
+    it "calls active with no args if no app_build is provided" do
+      allow(Split).to receive(:for_app_build).and_call_original
+      allow(Split).to receive(:active).and_call_original
+
+      expect(Split.for_presentation).to be_a(ActiveRecord::Relation)
+
+      expect(Split).to have_received(:active).with(no_args)
+      expect(Split).not_to have_received(:for_app_build)
+    end
+
+    it "calls for_app_build if app_build is provided" do
+      allow(Split).to receive(:for_app_build).and_call_original
+      app_build = FactoryBot.build_stubbed(:app).define_build(built_at: Time.zone.now, version: "1.0")
+
+      expect(Split.for_presentation(app_build: app_build)).to be_a(ActiveRecord::Relation)
+
+      expect(Split).to have_received(:for_app_build).with(app_build)
+    end
+  end
+
+  describe ".for_app_build" do
+    it "it calls active with built_at" do
+      allow(Split).to receive(:active).and_call_original
+      t = Time.zone.now
+      app_build = FactoryBot.build_stubbed(:app).define_build(built_at: t, version: "1.0")
+
+      expect(Split.for_app_build(app_build)).to be_a(ActiveRecord::Relation)
+
+      expect(Split).to have_received(:active).with(as_of: t)
+    end
+
+    it "calls with_feature_incomplete_knockouts_for with app_build" do
+      allow(Split).to receive(:with_feature_incomplete_knockouts_for).and_call_original
+      app_build = FactoryBot.build_stubbed(:app).define_build(built_at: Time.zone.now, version: "1.0")
+
+      expect(Split.for_app_build(app_build)).to be_a(ActiveRecord::Relation)
+
+      expect(Split).to have_received(:with_feature_incomplete_knockouts_for).with(app_build)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

This knocks out the split registry to 100% false for a given split in response to feature incompleteness on the current client app build. In conjunction with #100, it means that folks who are using a version of a client that is not feature complete for a given gate will not see any explicit assignments for that gate (PR #100's doing), and instead will see weightings of 100% false (this PR's doing) that cause the client to disable the feature.

There will be a future PR to add "hard" assignments that will win over these knockouts. I expect the weightings to remain knocked out in that case, we'll just ship the hard assignments to the client to layer over top.

/domain @Betterment/test_track_core 
/platform @smudge @samandmoore 