### PR TITLE
Hard assignments

### DIFF
--- a/app/controllers/admin/bulk_assignments_controller.rb
+++ b/app/controllers/admin/bulk_assignments_controller.rb
@@ -35,6 +35,6 @@ class Admin::BulkAssignmentsController < AuthenticatedAdminController
   def create_form_params
     params
       .require(:bulk_assignment_creation)
-      .permit(:identifiers_listing, :identifier_type_id, :variant, :reason, :force_identifier_creation)
+      .permit(:identifiers_listing, :identifier_type_id, :variant, :reason, :force_identifier_creation, :force)
   end
 end

--- a/app/controllers/api/v1/assignment_overrides_controller.rb
+++ b/app/controllers/api/v1/assignment_overrides_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::AssignmentOverridesController < SharedSecretAuthenticatedApiContr
   include CorsSupport
 
   def create
-    ArbitraryAssignmentCreation.create! create_params
+    ArbitraryAssignmentCreation.create! create_params.merge(force: true)
     head :no_content
   end
 

--- a/app/models/arbitrary_assignment_creation.rb
+++ b/app/models/arbitrary_assignment_creation.rb
@@ -1,4 +1,6 @@
 class ArbitraryAssignmentCreation
+  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context
+
   def initialize(params = {})
     @visitor_id = params[:visitor_id]
     @split_name = params[:split_name]
@@ -6,6 +8,7 @@ class ArbitraryAssignmentCreation
     @mixpanel_result = params[:mixpanel_result]
     @bulk_assignment_id = params[:bulk_assignment_id]
     @context = params[:context]
+    @force = params[:force] if params.key?(:force)
   end
 
   def save!
@@ -18,6 +21,10 @@ class ArbitraryAssignmentCreation
 
   def self.create!(params)
     new(params).tap(&:save!)
+  end
+
+  def force
+    instance_variable_defined?(:@force) ? @force : false
   end
 
   private
@@ -78,7 +85,8 @@ class ArbitraryAssignmentCreation
       variant: variant,
       mixpanel_result: mixpanel_result,
       bulk_assignment_id: bulk_assignment_id_for_save,
-      context: context_for_save
+      context: context_for_save,
+      force: force
     }
   end
 
@@ -110,6 +118,4 @@ class ArbitraryAssignmentCreation
       context_for_save
     end
   end
-
-  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context
 end

--- a/app/models/arbitrary_assignment_creation.rb
+++ b/app/models/arbitrary_assignment_creation.rb
@@ -1,15 +1,25 @@
 class ArbitraryAssignmentCreation
-  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context
+  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context, :force
 
-  def initialize(params = {})
-    @visitor_id = params[:visitor_id]
-    @split_name = params[:split_name]
-    @variant = params[:variant]
-    @mixpanel_result = params[:mixpanel_result]
-    @bulk_assignment_id = params[:bulk_assignment_id]
-    @context = params[:context]
-    @force = params[:force] if params.key?(:force)
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(
+    visitor_id: nil,
+    split_name: nil,
+    variant: nil,
+    mixpanel_result: nil,
+    bulk_assignment_id: nil,
+    context: nil,
+    force: false
+  )
+    @visitor_id = visitor_id
+    @split_name = split_name
+    @variant = variant
+    @mixpanel_result = mixpanel_result
+    @bulk_assignment_id = bulk_assignment_id
+    @context = context
+    @force = force
   end
+  # rubocop:enable Metrics/ParameterLists
 
   def save!
     if superseding?
@@ -20,11 +30,7 @@ class ArbitraryAssignmentCreation
   end
 
   def self.create!(params)
-    new(params).tap(&:save!)
-  end
-
-  def force
-    instance_variable_defined?(:@force) ? @force : false
+    new(params.to_h.symbolize_keys).tap(&:save!)
   end
 
   private

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -68,7 +68,8 @@ class Assignment < ActiveRecord::Base
       bulk_assignment_id: bulk_assignment_id,
       individually_overridden: individually_overridden,
       visitor_supersession_id: visitor_supersession_id,
-      context: context
+      context: context,
+      force: force
     }
   end
 

--- a/app/models/bulk_reassignment.rb
+++ b/app/models/bulk_reassignment.rb
@@ -38,7 +38,8 @@ class BulkReassignment
         bulk_assignment_id,
         individually_overridden,
         visitor_supersession_id,
-        context
+        context,
+        force
       )
       SELECT
         a.variant,
@@ -48,8 +49,9 @@ class BulkReassignment
         #{connection.quote(now)},
         a.bulk_assignment_id,
         a.individually_overridden,
-        visitor_supersession_id,
-        context
+        a.visitor_supersession_id,
+        a.context,
+        a.force
       FROM assignments a
       WHERE a.id #{assignment_id_clause}
     SQL
@@ -63,7 +65,8 @@ class BulkReassignment
         mixpanel_result = NULL,
         bulk_assignment_id = #{connection.quote(bulk_assignment)},
         visitor_supersession_id = NULL,
-        context = 'bulk_assignment'
+        context = 'bulk_assignment',
+        force = false
       WHERE id #{assignment_id_clause}
     SQL
   end

--- a/app/models/bulk_reassignment.rb
+++ b/app/models/bulk_reassignment.rb
@@ -57,7 +57,7 @@ class BulkReassignment
     SQL
   end
 
-  def update_assignments
+  def update_assignments # rubocop:disable Metrics/AbcSize
     connection.execute(<<-SQL)
       UPDATE assignments SET
         variant = #{connection.quote(bulk_assignment.variant)},
@@ -66,7 +66,7 @@ class BulkReassignment
         bulk_assignment_id = #{connection.quote(bulk_assignment)},
         visitor_supersession_id = NULL,
         context = 'bulk_assignment',
-        force = false
+        force = #{connection.quote(bulk_assignment.force)}
       WHERE id #{assignment_id_clause}
     SQL
   end

--- a/app/views/admin/bulk_assignments/new.html.erb
+++ b/app/views/admin/bulk_assignments/new.html.erb
@@ -33,5 +33,11 @@
   </div>
   <%= f.input :reason, placeholder: "e.g. Turn FeatureX on" %>
 
+  <div class="sc-m-v--s">
+  <%= f.input :force, as: :boolean, label: 'Alpha tester population? Allows
+  assignees to see known-incomplete or broken versions of this feature on
+  clients in the field.' %>
+  </div>
+
   <%= render "shared/form_footer", f: f, submit_text: "Assign To Split", submit_disable_with_text: "Assigning..." %>
 <% end %>

--- a/db/migrate/20190408143237_add_force_to_assignments.rb
+++ b/db/migrate/20190408143237_add_force_to_assignments.rb
@@ -1,0 +1,10 @@
+class AddForceToAssignments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :assignments, :force, :boolean
+    change_column_default :assignments, :force, from: nil, to: false
+    add_column :previous_assignments, :force, :boolean
+    change_column_default :previous_assignments, :force, from: nil, to: false
+    add_column :bulk_assignments, :force, :boolean
+    change_column_default :bulk_assignments, :force, from: nil, to: false
+  end
+end

--- a/db/migrate/20190408144258_backfill_assignments.rb
+++ b/db/migrate/20190408144258_backfill_assignments.rb
@@ -1,0 +1,19 @@
+class BackfillAssignments < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  def change
+    temp_assignments = Class.new(ActiveRecord::Base) do
+      self.table_name = "assignments"
+    end
+    temp_assignments.in_batches.update_all(force: false)
+
+    temp_previous_assignments = Class.new(ActiveRecord::Base) do
+      self.table_name = "previous_assignments"
+    end
+    temp_previous_assignments.in_batches.update_all(force: false)
+
+    temp_bulk_assignments = Class.new(ActiveRecord::Base) do
+      self.table_name = "bulk_assignments"
+    end
+    temp_bulk_assignments.in_batches.update_all(force: false)
+  end
+end

--- a/db/migrate/20190408145933_add_not_null_constraints.rb
+++ b/db/migrate/20190408145933_add_not_null_constraints.rb
@@ -1,0 +1,13 @@
+class AddNotNullConstraints < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  def up
+    execute "ALTER TABLE assignments ADD CONSTRAINT assignments_force_check CHECK (force IS NOT NULL) NOT VALID;"
+    execute "ALTER TABLE previous_assignments ADD CONSTRAINT previous_assignments_force_check CHECK (force IS NOT NULL) NOT VALID;"
+    execute "ALTER TABLE bulk_assignments ADD CONSTRAINT bulk_assignments_force_check CHECK (force IS NOT NULL) NOT VALID;"
+  end
+  def down
+    execute "ALTER TABLE assignments ADD CONSTRAINT assignments_force_check;"
+    execute "ALTER TABLE previous_assignments ADD CONSTRAINT previous_assignments_force_check;"
+    execute "ALTER TABLE bulk_assignments ADD CONSTRAINT bulk_assignments_force_check;"
+  end
+end

--- a/db/migrate/20190408145933_add_not_null_constraints.rb
+++ b/db/migrate/20190408145933_add_not_null_constraints.rb
@@ -6,8 +6,8 @@ class AddNotNullConstraints < ActiveRecord::Migration[5.1]
     execute "ALTER TABLE bulk_assignments ADD CONSTRAINT bulk_assignments_force_check CHECK (force IS NOT NULL) NOT VALID;"
   end
   def down
-    execute "ALTER TABLE assignments ADD CONSTRAINT assignments_force_check;"
-    execute "ALTER TABLE previous_assignments ADD CONSTRAINT previous_assignments_force_check;"
-    execute "ALTER TABLE bulk_assignments ADD CONSTRAINT bulk_assignments_force_check;"
+    execute "ALTER TABLE assignments DROP CONSTRAINT assignments_force_check;"
+    execute "ALTER TABLE previous_assignments DROP CONSTRAINT previous_assignments_force_check;"
+    execute "ALTER TABLE bulk_assignments DROP CONSTRAINT bulk_assignments_force_check;"
   end
 end

--- a/db/migrate/20190409164425_validate_not_null_constriants.rb
+++ b/db/migrate/20190409164425_validate_not_null_constriants.rb
@@ -1,0 +1,12 @@
+class ValidateNotNullConstriants < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  def up
+    execute "ALTER TABLE assignments VALIDATE CONSTRAINT assignments_force_check;"
+    execute "ALTER TABLE previous_assignments VALIDATE CONSTRAINT previous_assignments_force_check;"
+    execute "ALTER TABLE bulk_assignments VALIDATE CONSTRAINT bulk_assignments_force_check;"
+  end
+
+  def down
+    # Validating doesn't need undoing
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 20190409164425) do
     t.uuid "bulk_assignment_id"
     t.uuid "visitor_supersession_id"
     t.string "context"
-    t.boolean "force", default: false
+    t.boolean "force", default: false, null: false
     t.index ["bulk_assignment_id"], name: "index_assignments_on_bulk_assignment_id"
     t.index ["split_id", "visitor_id"], name: "index_assignments_on_split_id_and_visitor_id", unique: true
     t.index ["split_id"], name: "index_assignments_on_split_id"
@@ -81,7 +81,7 @@ ActiveRecord::Schema.define(version: 20190409164425) do
     t.string "variant", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean "force", default: false
+    t.boolean "force", default: false, null: false
   end
 
   create_table "delayed_jobs", id: :serial, force: :cascade do |t|
@@ -129,7 +129,7 @@ ActiveRecord::Schema.define(version: 20190409164425) do
     t.boolean "individually_overridden", default: false, null: false
     t.string "context"
     t.uuid "visitor_supersession_id"
-    t.boolean "force", default: false
+    t.boolean "force", default: false, null: false
     t.index ["assignment_id"], name: "index_previous_assignments_on_assignment_id"
     t.index ["superseded_at"], name: "index_previous_assignments_on_superseded_at"
     t.index ["visitor_supersession_id"], name: "index_previous_assignments_on_visitor_supersession_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190401094449) do
+ActiveRecord::Schema.define(version: 20190409164425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,7 @@ ActiveRecord::Schema.define(version: 20190401094449) do
     t.uuid "bulk_assignment_id"
     t.uuid "visitor_supersession_id"
     t.string "context"
+    t.boolean "force", default: false
     t.index ["bulk_assignment_id"], name: "index_assignments_on_bulk_assignment_id"
     t.index ["split_id", "visitor_id"], name: "index_assignments_on_split_id_and_visitor_id", unique: true
     t.index ["split_id"], name: "index_assignments_on_split_id"
@@ -80,6 +81,7 @@ ActiveRecord::Schema.define(version: 20190401094449) do
     t.string "variant", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "force", default: false
   end
 
   create_table "delayed_jobs", id: :serial, force: :cascade do |t|
@@ -127,6 +129,7 @@ ActiveRecord::Schema.define(version: 20190401094449) do
     t.boolean "individually_overridden", default: false, null: false
     t.string "context"
     t.uuid "visitor_supersession_id"
+    t.boolean "force", default: false
     t.index ["assignment_id"], name: "index_previous_assignments_on_assignment_id"
     t.index ["superseded_at"], name: "index_previous_assignments_on_superseded_at"
     t.index ["visitor_supersession_id"], name: "index_previous_assignments_on_visitor_supersession_id"

--- a/spec/controllers/api/v1/assignment_overrides_controller_spec.rb
+++ b/spec/controllers/api/v1/assignment_overrides_controller_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Api::V1::AssignmentOverridesController, type: :controller do
           expect(assignment.split).to eq split
           expect(assignment.mixpanel_result).to eq "success"
           expect(assignment.context).to eq "context"
+          expect(assignment.force).to eq true
         end
 
         it "overrides an assignment if one already exists" do
@@ -65,6 +66,8 @@ RSpec.describe Api::V1::AssignmentOverridesController, type: :controller do
             post :create, params: create_params
           }.to change { PreviousAssignment.count }.by(1)
 
+          expect(Assignment.last.force).to eq true
+          expect(PreviousAssignment.last.force).to eq false
           expect(response).to have_http_status :no_content
         end
 

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -229,4 +229,22 @@ RSpec.describe Assignment, type: :model do
       expect(described_class.excluding_incomplete_features_for(app_build)).not_to include(assignment)
     end
   end
+
+  describe "#create_previous_assignment" do
+    it "passes back a true force value" do
+      assignment = FactoryBot.create(:assignment, force: true)
+      previous_assignment = assignment.create_previous_assignment!(Time.zone.now)
+
+      expect(previous_assignment).to be_a PreviousAssignment
+      expect(previous_assignment.force).to eq(true)
+    end
+
+    it "passes back a false force value" do
+      assignment = FactoryBot.create(:assignment, force: false)
+      previous_assignment = assignment.create_previous_assignment!(Time.zone.now)
+
+      expect(previous_assignment).to be_a PreviousAssignment
+      expect(previous_assignment.force).to eq(false)
+    end
+  end
 end

--- a/spec/models/bulk_assignment_creation_spec.rb
+++ b/spec/models/bulk_assignment_creation_spec.rb
@@ -174,11 +174,61 @@ RSpec.describe BulkAssignmentCreation do
       expect(previous_assignments.find_by(variant: "yes").bulk_assignment).to be_nil
     end
 
-    it "assigns the specified population to the same variant" do
+    it "assigns the specified population to the same variant and force value" do
       bulk_assign_create = subject.tap(&:save)
 
       expect(bulk_assign_create.variant).to eq "no"
       expect(Assignment.all.map(&:variant).uniq).to match_array ["no"]
+      expect(bulk_assign_create.force).to eq false
+      expect(Assignment.all.map(&:force).uniq).to match_array [false]
+    end
+
+    describe "with force true" do
+      let(:create_params) do
+        {
+          identifiers_listing: ids_csv,
+          identifier_type_id: identifier_type.id,
+          variant: "no",
+          reason: "because i felt like it",
+          split: split,
+          admin: admin,
+          force_identifier_creation: '1',
+          force: true
+        }
+      end
+
+      it "assigns the specified population to the same variant and force value" do
+        bulk_assign_create = subject.tap(&:save)
+
+        expect(bulk_assign_create.variant).to eq "no"
+        expect(Assignment.all.map(&:variant).uniq).to match_array ["no"]
+        expect(bulk_assign_create.force).to eq true
+        expect(Assignment.all.map(&:force).uniq).to match_array [true]
+      end
+    end
+
+    describe "with force true and variant unchanged" do
+      let(:create_params) do
+        {
+          identifiers_listing: ids_csv,
+          identifier_type_id: identifier_type.id,
+          variant: "yes",
+          reason: "because i felt like it",
+          split: split,
+          admin: admin,
+          force_identifier_creation: '1',
+          force: true
+        }
+      end
+
+      it "assigns the specified population to the same variant and force value" do
+        bulk_assign_create = subject.tap(&:save)
+
+        expect(bulk_assign_create.variant).to eq "yes"
+        expect(Assignment.all.map(&:variant).uniq).to match_array ["yes"]
+        expect(bulk_assign_create.force).to eq true
+        expect(Assignment.all.map(&:force).uniq).to match_array [true]
+      end
     end
 
     it "creates new Visitors and Identifiers for unidentified ids" do

--- a/spec/models/bulk_reassignment_spec.rb
+++ b/spec/models/bulk_reassignment_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe BulkReassignment do
       visitor_supersession: visitor_supersession,
       bulk_assignment: old_bulk_assignment,
       created_at: 7.minutes.ago,
-      updated_at: 7.minutes.ago
+      updated_at: 7.minutes.ago,
+      force: true
     }
   end
   let!(:assignments) { FactoryBot.create_list(:assignment, 2, assignment_attrs) }
@@ -94,6 +95,10 @@ RSpec.describe BulkReassignment do
       expect(assignment.previous_assignments.length).to eq 1
     end
 
+    it "toggles force to false" do
+      expect(assignment.force).to eq(false)
+    end
+
     context "within the created previous_assignment record" do
       let(:previous_assignment) { assignment.previous_assignments.first }
 
@@ -123,6 +128,10 @@ RSpec.describe BulkReassignment do
 
       it "preserves old visitor_supersession_id" do
         expect(previous_assignment.visitor_supersession_id).to eq visitor_supersession.id
+      end
+
+      it "preserves old force" do
+        expect(previous_assignment.force).to eq(true)
       end
     end
   end


### PR DESCRIPTION
### Summary

Adds a force flag to assignments which will later be plumbed into assignment hiding logic for app_feature_incompletions and app_remote_kills. Using this column for presentation comes later, and that's fine because no endpoints currently available will be impacted by the force flag.

### Other Information

The tests here are very high level, but actually give a lot of confidence. There were still-other tests that failed along the way and showed me where I was under-implementing this feature. I'm not sure the test strategy is super opinionated for all these models in general, but this testing strategy feels coherent with the way tests had been written before. What are your thoughts on that?

There's also a detail here that's kind of annoying - I want to add a not-null column to a potentially-very-large table (assignments). The safest way to do that is not supported by ActiveRecord migrations. I'm proposing that I do it the safe way, and then lie about how I did it in the schema file, intentionally introducing a dissonance between how the constraint is implemented between the production database (of an existing install that is migrated up) and any database built from the latest schema.rb.

I'll have comments below about this.

/domain @Betterment/test_track_core 
/platform @samandmoore @smudge 
/domain @alederman @bslakter for migration questions