### PR TITLE
add sleeps to keep from slamming server, batch size 10k

### DIFF
--- a/db/migrate/20190408144258_backfill_assignments.rb
+++ b/db/migrate/20190408144258_backfill_assignments.rb
@@ -4,16 +4,25 @@ class BackfillAssignments < ActiveRecord::Migration[5.1]
     temp_assignments = Class.new(ActiveRecord::Base) do
       self.table_name = "assignments"
     end
-    temp_assignments.in_batches.update_all(force: false)
+    temp_assignments.in_batches(of: 10_000) do |batch|
+      batch.update_all(force: false)
+      sleep(0.1)
+    end
 
     temp_previous_assignments = Class.new(ActiveRecord::Base) do
       self.table_name = "previous_assignments"
     end
-    temp_previous_assignments.in_batches.update_all(force: false)
+    temp_previous_assignments.in_batches(of: 10_000) do |batch|
+      batch.update_all(force: false)
+      sleep(0.1)
+    end
 
     temp_bulk_assignments = Class.new(ActiveRecord::Base) do
       self.table_name = "bulk_assignments"
     end
-    temp_bulk_assignments.in_batches.update_all(force: false)
+    temp_bulk_assignments.in_batches(of: 10_000) do |batch|
+      batch.update_all(force: false)
+      sleep(0.1)
+    end
   end
 end


### PR DESCRIPTION
### Summary

Looks like the backfill causes latency jitter when saturating IOPS on our stage database. Adding sleeps to tone it down a little bit and see how that treats us.

### Other Information

/domain @alederman @bslakter
/no-platform
