### PR TITLE
Feature completion migration endpoint

### DIFF
--- a/app/controllers/api/v2/migrations/app_feature_completions_controller.rb
+++ b/app/controllers/api/v2/migrations/app_feature_completions_controller.rb
@@ -1,14 +1,10 @@
 class Api::V2::Migrations::AppFeatureCompletionsController < AuthenticatedApiController
   def create
-    feature_gate = Split.find_by(name: create_params[:feature_gate])
-    feature_completion = current_app.feature_completions.find_or_initialize_by(
-      feature_gate: feature_gate,
-      version: AppVersion.new(create_params[:version])
-    )
-    if feature_completion.save
+    feature_completion_migration = AppFeatureCompletionMigration.new(create_params.merge(app: current_app))
+    if feature_completion_migration.save
       head :no_content
     else
-      render_errors feature_completion
+      render_errors feature_completion_migration
     end
   end
 

--- a/app/controllers/api/v2/migrations/app_feature_completions_controller.rb
+++ b/app/controllers/api/v2/migrations/app_feature_completions_controller.rb
@@ -1,0 +1,20 @@
+class Api::V2::Migrations::AppFeatureCompletionsController < AuthenticatedApiController
+  def create
+    feature_gate = Split.find_by(name: create_params[:feature_gate])
+    feature_completion = current_app.feature_completions.find_or_initialize_by(
+      feature_gate: feature_gate,
+      version: AppVersion.new(create_params[:version])
+    )
+    if feature_completion.save
+      head :no_content
+    else
+      render_errors feature_completion
+    end
+  end
+
+  private
+
+  def create_params
+    params.permit(:feature_gate, :version)
+  end
+end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -1,6 +1,7 @@
 class App < ActiveRecord::Base
   has_many :splits, foreign_key: :owner_app_id, dependent: :nullify, inverse_of: :owner_app
   has_many :identifier_types, foreign_key: :owner_app_id, dependent: :nullify, inverse_of: :owner_app
+  has_many :feature_completions, class_name: "AppFeatureCompletion", dependent: :nullify
 
   validates :name, :auth_secret, presence: true
   validates :name, uniqueness: true

--- a/app/models/app_feature_completion.rb
+++ b/app/models/app_feature_completion.rb
@@ -1,16 +1,25 @@
 class AppFeatureCompletion < ActiveRecord::Base
   belongs_to :app
-  belongs_to :split
+  belongs_to :feature_gate, class_name: "Split"
 
   attribute :version, :app_version
 
-  validates :app, :split, :version, presence: true
-  validates :split, uniqueness: { scope: :app }
+  validates :app, :feature_gate, :version, presence: true
+  validates :feature_gate, uniqueness: { scope: :app }
+  validate :feature_gate_must_be_a_feature_gate
 
   scope :satisfied_by, ->(app_build) do
     where(
       arel_table[:app_id].eq(app_build.app_id)
       .and(arel_table[:version].lteq(app_build.version))
     )
+  end
+
+  private
+
+  def feature_gate_must_be_a_feature_gate
+    return if feature_gate.nil?
+
+    errors.add(:feature_gate, "must be a feature gate") unless feature_gate.feature_gate?
   end
 end

--- a/app/models/app_feature_completion_migration.rb
+++ b/app/models/app_feature_completion_migration.rb
@@ -1,0 +1,57 @@
+class AppFeatureCompletionMigration
+  include ActiveModel::Validations
+
+  attr_reader :app, :feature_gate, :version_before_type_cast
+
+  validate :feature_gate_must_exist
+
+  delegate :version, to: :app_feature_completion
+
+  def initialize(params)
+    @app = params[:app] || raise("Must provide app")
+    @feature_gate = params[:feature_gate]
+    app_feature_completion.version = @version_before_type_cast = params[:version]
+  end
+
+  def valid?
+    if version_before_type_cast
+      app_feature_completion.valid?
+    else
+      super
+    end
+  end
+
+  def errors
+    if version_before_type_cast
+      app_feature_completion.errors
+    else
+      super
+    end
+  end
+
+  def save
+    if version_before_type_cast
+      app_feature_completion.save
+    else
+      if valid? && app_feature_completion.persisted?
+        app_feature_completion.destroy.destroyed?
+      else
+        false
+      end
+    end
+  end
+
+  def app_feature_completion
+    @app_feature_completion ||= app.feature_completions.find_or_initialize_by(feature_gate: feature_gate_model)
+  end
+
+  def feature_gate_model
+    Split.find_by(name: feature_gate)
+  end
+
+  private
+
+  def feature_gate_must_exist
+    errors.add(:feature_gate, "must exist") unless feature_gate_model
+  end
+end

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -53,7 +53,7 @@ class Split < ActiveRecord::Base
       arel_table[:feature_gate].eq(false)
       .or(
         AppFeatureCompletion.select(1).satisfied_by(app_build).arel
-        .where(AppFeatureCompletion.arel_table[:split_id].eq(arel_table[:id]))
+        .where(AppFeatureCompletion.arel_table[:feature_gate_id].eq(arel_table[:id]))
         .exists
       )
     )

--- a/app/types/app_version_type.rb
+++ b/app/types/app_version_type.rb
@@ -6,7 +6,7 @@ class AppVersionType < ActiveRecord::Type::Value
   end
 
   def serialize(value)
-    value.to_pg_array if value
+    AppVersion.new(value).to_pg_array if value
   end
 
   def deserialize(value)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,10 @@ Rails.application.routes.draw do
 
     namespace :v2 do
       resource :split_registry, only: :show
+
+      namespace :migrations do
+        resource :app_feature_completion
+      end
     end
   end
 

--- a/db/migrate/20190413110639_app_feature_completion_split_to_feature_gate.rb
+++ b/db/migrate/20190413110639_app_feature_completion_split_to_feature_gate.rb
@@ -1,0 +1,5 @@
+class AppFeatureCompletionSplitToFeatureGate < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :app_feature_completions, :split_id, :feature_gate_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190409231451) do
+ActiveRecord::Schema.define(version: 20190413110639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,13 +39,13 @@ ActiveRecord::Schema.define(version: 20190409231451) do
 
   create_table "app_feature_completions", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "app_id", null: false
-    t.uuid "split_id", null: false
+    t.uuid "feature_gate_id", null: false
     t.integer "version", null: false, array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["app_id"], name: "index_app_feature_completions_on_app_id"
-    t.index ["split_id", "app_id"], name: "index_app_feature_completions_on_split_id_and_app_id", unique: true
-    t.index ["split_id"], name: "index_app_feature_completions_on_split_id"
+    t.index ["feature_gate_id", "app_id"], name: "index_app_feature_completions_on_feature_gate_id_and_app_id", unique: true
+    t.index ["feature_gate_id"], name: "index_app_feature_completions_on_feature_gate_id"
   end
 
   create_table "app_remote_kills", force: :cascade do |t|
@@ -208,7 +208,7 @@ ActiveRecord::Schema.define(version: 20190409231451) do
   end
 
   add_foreign_key "app_feature_completions", "apps"
-  add_foreign_key "app_feature_completions", "splits"
+  add_foreign_key "app_feature_completions", "splits", column: "feature_gate_id"
   add_foreign_key "app_remote_kills", "apps"
   add_foreign_key "app_remote_kills", "splits"
   add_foreign_key "assignments", "bulk_assignments"

--- a/spec/controllers/api/v2/migrations/app_feature_completions_controller_spec.rb
+++ b/spec/controllers/api/v2/migrations/app_feature_completions_controller_spec.rb
@@ -33,11 +33,22 @@ RSpec.describe Api::V2::Migrations::AppFeatureCompletionsController do
       expect(feature_completion.version).to eq(AppVersion.new("1.0"))
     end
 
-    it "destroys feature completions with null version" do
+    it "destroys feature completions with null version via JSON request" do
       FactoryBot.create(:app_feature_completion, app: app, feature_gate: feature_gate, version: "1.0")
 
       http_authenticate username: app.name, auth_secret: app.auth_secret
       post :create, params: { feature_gate: feature_gate.name, version: nil }, as: :json
+
+      expect(response).to have_http_status(:no_content)
+
+      expect(app.feature_completions).to be_empty
+    end
+
+    it "destroys feature completions with null version via URLENCODED request" do
+      FactoryBot.create(:app_feature_completion, app: app, feature_gate: feature_gate, version: "1.0")
+
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: { feature_gate: feature_gate.name, version: nil }
 
       expect(response).to have_http_status(:no_content)
 

--- a/spec/controllers/api/v2/migrations/app_feature_completions_controller_spec.rb
+++ b/spec/controllers/api/v2/migrations/app_feature_completions_controller_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Api::V2::Migrations::AppFeatureCompletionsController do
   describe "#create" do
     it "is unauthorized with bad auth" do
       http_authenticate username: app.name, auth_secret: 'bad bad bad'
-      post :create
+      post :create, as: :json
       expect(response).to have_http_status :unauthorized
     end
 
     it "persists with a well-formed request" do
       http_authenticate username: app.name, auth_secret: app.auth_secret
-      post :create, params: { feature_gate: feature_gate.name, version: "1.0" }
+      post :create, params: { feature_gate: feature_gate.name, version: "1.0" }, as: :json
 
       expect(response).to have_http_status(:no_content)
       result = app.feature_completions.first
@@ -22,9 +22,31 @@ RSpec.describe Api::V2::Migrations::AppFeatureCompletionsController do
       expect(result.version).to eq(AppVersion.new("1.0"))
     end
 
-    it "blows up with an experiment" do
+    it "updates an existing feature completion with a well-formed request" do
+      feature_completion = FactoryBot.create(:app_feature_completion, app: app, feature_gate: feature_gate, version: "0.9")
       http_authenticate username: app.name, auth_secret: app.auth_secret
-      post :create, params: { feature_gate: experiment.name, version: "1.0" }
+      post :create, params: { feature_gate: feature_gate.name, version: "1.0" }, as: :json
+
+      expect(response).to have_http_status(:no_content)
+
+      feature_completion.reload
+      expect(feature_completion.version).to eq(AppVersion.new("1.0"))
+    end
+
+    it "destroys feature completions with null version" do
+      FactoryBot.create(:app_feature_completion, app: app, feature_gate: feature_gate, version: "1.0")
+
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: { feature_gate: feature_gate.name, version: nil }, as: :json
+
+      expect(response).to have_http_status(:no_content)
+
+      expect(app.feature_completions).to be_empty
+    end
+
+    it "is invalid with an experiment" do
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: { feature_gate: experiment.name, version: "1.0" }, as: :json
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response_json['errors']['feature_gate'].first).to include("must be a feature gate")

--- a/spec/controllers/api/v2/migrations/app_feature_completions_controller_spec.rb
+++ b/spec/controllers/api/v2/migrations/app_feature_completions_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::Migrations::AppFeatureCompletionsController do
+  let(:feature_gate) { FactoryBot.create(:feature_gate) }
+  let(:experiment) { FactoryBot.create(:experiment) }
+  let(:app) { FactoryBot.create(:app) }
+
+  describe "#create" do
+    it "is unauthorized with bad auth" do
+      http_authenticate username: app.name, auth_secret: 'bad bad bad'
+      post :create
+      expect(response).to have_http_status :unauthorized
+    end
+
+    it "persists with a well-formed request" do
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: { feature_gate: feature_gate.name, version: "1.0" }
+
+      expect(response).to have_http_status(:no_content)
+      result = app.feature_completions.first
+      expect(result.feature_gate).to eq(feature_gate)
+      expect(result.version).to eq(AppVersion.new("1.0"))
+    end
+
+    it "blows up with an experiment" do
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: { feature_gate: experiment.name, version: "1.0" }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response_json['errors']['feature_gate'].first).to include("must be a feature gate")
+    end
+  end
+end

--- a/spec/factories/app_feature_completions.rb
+++ b/spec/factories/app_feature_completions.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :app_feature_completion do
-    split
+    feature_gate
     app
     version { "1.0" }
   end

--- a/spec/factories/splits.rb
+++ b/spec/factories/splits.rb
@@ -3,5 +3,17 @@ FactoryBot.define do
     sequence(:name) { |i| "split_#{i}" }
     association :owner_app, factory: :app
     registry { { hammer_time: 100, touch_this: 0 } }
+
+    factory(:experiment) do
+      sequence(:name) { |i| "try_#{i}_experiment" }
+      feature_gate { false }
+      registry { { control: 50, treatment: 50 } }
+    end
+
+    factory :feature_gate do
+      sequence(:name) { |i| "feature_#{i}_enabled" }
+      feature_gate { true }
+      registry { { false: 100, true: 0 } }
+    end
   end
 end

--- a/spec/models/app_feature_completion_migration_spec.rb
+++ b/spec/models/app_feature_completion_migration_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe AppFeatureCompletionMigration do
+  let(:app) { FactoryBot.create(:app) }
+  let(:feature_gate) { FactoryBot.create(:feature_gate) }
+  let(:experiment) { FactoryBot.create(:experiment) }
+
+  it "creates AppFeatureCompletions" do
+    subject = described_class.new(app: app, feature_gate: feature_gate.name, version: "1.0")
+
+    expect(subject.save).to eq true
+
+    expect(app.feature_completions.where(feature_gate: feature_gate, version: "1.0")).to be_present
+  end
+
+  it "destroys AppFeatureCompletions" do
+    FactoryBot.create(:app_feature_completion, app: app, feature_gate: feature_gate, version: "1.0")
+    subject = described_class.new(app: app, feature_gate: feature_gate.name, version: nil)
+
+    expect(subject.save).to eq true
+
+    expect(app.feature_completions.where(feature_gate: feature_gate, version: "1.0")).not_to be_present
+  end
+
+  it "is invalid with no feature gate" do
+    subject = described_class.new(app: app, feature_gate: "nonexistent_enabled", version: "1.0")
+
+    expect(subject).to have(1).error_on(:feature_gate)
+    expect(subject.save).to eq false
+  end
+
+  it "is invalid when destroying a nonexistant feature gate" do
+    subject = described_class.new(app: app, feature_gate: "nonexistent_enabled", version: nil)
+
+    expect(subject).to have(1).error_on(:feature_gate)
+    expect(subject).to have_no.errors_on(:version)
+    expect(subject.save).to eq false
+  end
+
+  it "is invalid with an experiment" do
+    subject = described_class.new(app: app, feature_gate: experiment, version: "1.0")
+
+    expect(subject).to have(1).error_on(:feature_gate)
+    expect(subject.save).to eq false
+  end
+
+  it "blows up with no app" do
+    expect {
+      described_class.new(app: nil, feature_gate: feature_gate.name, version: "1.0")
+    }.to raise_error(/Must provide app/)
+  end
+
+  it "is invalid with an unparseable version" do
+    subject = described_class.new(app: app, feature_gate: feature_gate.name, version: "01.0")
+
+    expect(subject).to have(1).error_on(:version)
+    expect(subject.save).to eq false
+  end
+end

--- a/spec/models/app_feature_completion_migration_spec.rb
+++ b/spec/models/app_feature_completion_migration_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe AppFeatureCompletionMigration do
     expect(app.feature_completions.where(feature_gate: feature_gate, version: "1.0")).to be_present
   end
 
+  it "updates AppFeatureCompletions" do
+    feature_completion = FactoryBot.create(:app_feature_completion, app: app, feature_gate: feature_gate, version: "0.9")
+    subject = described_class.new(app: app, feature_gate: feature_gate.name, version: "1.0")
+
+    expect(subject.save).to eq true
+
+    feature_completion.reload
+    expect(feature_completion.version).to eq(AppVersion.new("1.0"))
+  end
+
   it "destroys AppFeatureCompletions" do
     FactoryBot.create(:app_feature_completion, app: app, feature_gate: feature_gate, version: "1.0")
     subject = described_class.new(app: app, feature_gate: feature_gate.name, version: nil)
@@ -22,6 +32,23 @@ RSpec.describe AppFeatureCompletionMigration do
     expect(app.feature_completions.where(feature_gate: feature_gate, version: "1.0")).not_to be_present
   end
 
+  it "destroys AppFeatureCompletions with empty-string version" do
+    FactoryBot.create(:app_feature_completion, app: app, feature_gate: feature_gate, version: "1.0")
+    subject = described_class.new(app: app, feature_gate: feature_gate.name, version: "")
+
+    expect(subject.save).to eq true
+
+    expect(app.feature_completions.where(feature_gate: feature_gate, version: "1.0")).not_to be_present
+  end
+
+  it "is invalid when destroying for a nonexistant feature gate" do
+    subject = described_class.new(app: app, feature_gate: "nonexistent_enabled", version: nil)
+
+    expect(subject).to have(1).error_on(:feature_gate)
+    expect(subject).to have(0).errors_on(:version)
+    expect(subject.save).to eq false
+  end
+
   it "is invalid with no feature gate" do
     subject = described_class.new(app: app, feature_gate: "nonexistent_enabled", version: "1.0")
 
@@ -29,12 +56,12 @@ RSpec.describe AppFeatureCompletionMigration do
     expect(subject.save).to eq false
   end
 
-  it "is invalid when destroying a nonexistant feature gate" do
-    subject = described_class.new(app: app, feature_gate: "nonexistent_enabled", version: nil)
+  it "is valid when destroying an unpersisted feature completion for idempotency" do
+    subject = described_class.new(app: app, feature_gate: feature_gate.name, version: nil)
 
-    expect(subject).to have(1).error_on(:feature_gate)
-    expect(subject).to have_no.errors_on(:version)
-    expect(subject.save).to eq false
+    expect(subject.save).to eq true
+
+    expect(app.feature_completions.where(feature_gate: feature_gate, version: "1.0")).not_to be_present
   end
 
   it "is invalid with an experiment" do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Assignment, type: :model do
 
   describe ".excluding_incomplete_features_for" do
     it "returns assignments to non-gates for which no app_feature_completion exists" do
-      split = FactoryBot.create(:split, feature_gate: false)
+      split = FactoryBot.create(:experiment)
       assignment = FactoryBot.create(:assignment, split: split)
       app_build = split.owner_app.define_build(built_at: Time.zone.now, version: "1.0.1")
 
@@ -195,45 +195,45 @@ RSpec.describe Assignment, type: :model do
     end
 
     it "returns assignments for features completed before the provided version" do
-      split = FactoryBot.create(:split, feature_gate: true)
+      split = FactoryBot.create(:feature_gate)
       assignment = FactoryBot.create(:assignment, split: split)
-      app_feature_completion = FactoryBot.create(:app_feature_completion, split: split, version: "1.0.0")
+      app_feature_completion = FactoryBot.create(:app_feature_completion, feature_gate: split, version: "1.0.0")
       app_build = app_feature_completion.app.define_build(built_at: Time.zone.now, version: "1.0.1")
 
       expect(described_class.excluding_incomplete_features_for(app_build)).to include(assignment)
     end
 
     it "returns assignments for features completed at the provided version" do
-      split = FactoryBot.create(:split, feature_gate: true)
+      split = FactoryBot.create(:feature_gate)
       assignment = FactoryBot.create(:assignment, split: split)
-      app_feature_completion = FactoryBot.create(:app_feature_completion, split: split, version: "1.0.0")
+      app_feature_completion = FactoryBot.create(:app_feature_completion, feature_gate: split, version: "1.0.0")
       app_build = app_feature_completion.app.define_build(built_at: Time.zone.now, version: "1.0.0")
 
       expect(described_class.excluding_incomplete_features_for(app_build)).to include(assignment)
     end
 
     it "doesn't return assignments for features completed after the provided version" do
-      split = FactoryBot.create(:split, feature_gate: true)
+      split = FactoryBot.create(:feature_gate)
       assignment = FactoryBot.create(:assignment, split: split)
-      app_feature_completion = FactoryBot.create(:app_feature_completion, split: split, version: "1.0.0")
+      app_feature_completion = FactoryBot.create(:app_feature_completion, feature_gate: split, version: "1.0.0")
       app_build = app_feature_completion.app.define_build(built_at: Time.zone.now, version: "0.9.48")
 
       expect(described_class.excluding_incomplete_features_for(app_build)).not_to include(assignment)
     end
 
     it "returns assignments for features completed after the provided version if forced" do
-      split = FactoryBot.create(:split, feature_gate: true)
+      split = FactoryBot.create(:feature_gate)
       assignment = FactoryBot.create(:assignment, split: split, force: true)
-      app_feature_completion = FactoryBot.create(:app_feature_completion, split: split, version: "1.0.0")
+      app_feature_completion = FactoryBot.create(:app_feature_completion, feature_gate: split, version: "1.0.0")
       app_build = app_feature_completion.app.define_build(built_at: Time.zone.now, version: "0.9.48")
 
       expect(described_class.excluding_incomplete_features_for(app_build)).to include(assignment)
     end
 
     it "doesn't return assignments for features completed on a different app" do
-      split = FactoryBot.create(:split, feature_gate: true)
+      split = FactoryBot.create(:feature_gate)
       assignment = FactoryBot.create(:assignment, split: split)
-      FactoryBot.create(:app_feature_completion, split: split, version: "1.0.0")
+      FactoryBot.create(:app_feature_completion, feature_gate: split, version: "1.0.0")
       other_app = FactoryBot.create(:app)
       app_build = other_app.define_build(built_at: Time.zone.now, version: "1.0.0")
 
@@ -241,7 +241,7 @@ RSpec.describe Assignment, type: :model do
     end
 
     it "returns assignments for features never completed if forced" do
-      split = FactoryBot.create(:split, feature_gate: true)
+      split = FactoryBot.create(:feature_gate)
       assignment = FactoryBot.create(:assignment, split: split, force: true)
       app = FactoryBot.create(:app)
       app_build = app.define_build(built_at: Time.zone.now, version: "1.0.0")


### PR DESCRIPTION
### Summary

This adds a new migration endpoint to create/update/destroy feature completions. I renamed a the AppFeatureCompletion.split_id column to feature_gate_id in the process and validated that it's the right kind of split now that I'm shoring this up for data integrity while receiving untrusted input.

I'll drop a comment with the version range that's real because this includes `remote_kill`'s commits right now.

/domain @Betterment/test_track_core 
/platform @samandmoore @smudge 
