### PR TITLE
Remote kill migration endpoint

### DIFF
--- a/app/controllers/api/v2/migrations/app_remote_kills_controller.rb
+++ b/app/controllers/api/v2/migrations/app_remote_kills_controller.rb
@@ -1,0 +1,16 @@
+class Api::V2::Migrations::AppRemoteKillsController < AuthenticatedApiController
+  def create
+    remote_kill_migration = AppRemoteKillMigration.new(create_params.merge(app: current_app))
+    if remote_kill_migration.save
+      head :no_content
+    else
+      render_errors remote_kill_migration
+    end
+  end
+
+  private
+
+  def create_params
+    params.permit(:split, :reason, :override_to, :first_bad_version, :fixed_version)
+  end
+end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -2,6 +2,7 @@ class App < ActiveRecord::Base
   has_many :splits, foreign_key: :owner_app_id, dependent: :nullify, inverse_of: :owner_app
   has_many :identifier_types, foreign_key: :owner_app_id, dependent: :nullify, inverse_of: :owner_app
   has_many :feature_completions, class_name: "AppFeatureCompletion", dependent: :nullify
+  has_many :remote_kills, class_name: "AppRemoteKill", dependent: :nullify
 
   validates :name, :auth_secret, presence: true
   validates :name, uniqueness: true

--- a/app/models/app_remote_kill.rb
+++ b/app/models/app_remote_kill.rb
@@ -10,7 +10,6 @@ class AppRemoteKill < ActiveRecord::Base
     uniqueness: { scope: %i(app split) },
     format: { with: /\A[a-z\d_]*\z/, message: "must be alphanumeric snake_case" }
 
-  validate :override_to_must_exist
   validate :fixed_version_must_be_greater_than_first_bad_version
   validate :must_not_overlap_existing
 
@@ -54,12 +53,6 @@ class AppRemoteKill < ActiveRecord::Base
       arel_table[:fixed_version].eq(nil)
       .or(arel_table[:fixed_version].gt(version))
     )
-  end
-
-  def override_to_must_exist
-    return unless split
-
-    errors.add(:override_to, "must exist in split's current variants") unless split.has_variant?(override_to)
   end
 
   def fixed_version_must_be_greater_than_first_bad_version

--- a/app/models/app_remote_kill.rb
+++ b/app/models/app_remote_kill.rb
@@ -6,7 +6,9 @@ class AppRemoteKill < ActiveRecord::Base
   attribute :fixed_version, :app_version
 
   validates :app, :split, :reason, :override_to, :first_bad_version, presence: true
-  validates :reason, uniqueness: { scope: %i(app split) }
+  validates :reason,
+    uniqueness: { scope: %i(app split) },
+    format: { with: /\A[a-z\d_]*\z/, message: "must be alphanumeric snake_case" }
 
   validate :override_to_must_exist
   validate :fixed_version_must_be_greater_than_first_bad_version

--- a/app/models/app_remote_kill_migration.rb
+++ b/app/models/app_remote_kill_migration.rb
@@ -1,0 +1,36 @@
+class AppRemoteKillMigration
+  include ActiveModel::Validations
+
+  attr_reader :app,
+    :split,
+    :reason
+
+  delegate :override_to,
+    :first_bad_version,
+    :fixed_version,
+    :save,
+    :valid?,
+    :errors,
+    to: :app_remote_kill
+
+  def initialize(params)
+    @app = params[:app] || raise("Must provide app")
+    @split = params[:split]
+    @reason = params[:reason]
+    app_remote_kill.assign_attributes(
+      override_to: params[:override_to],
+      first_bad_version: params[:first_bad_version],
+      fixed_version: params[:fixed_version]
+    )
+  end
+
+  private
+
+  def app_remote_kill
+    @app_remote_kill ||= app.remote_kills.find_or_initialize_by(split: split_model, reason: reason)
+  end
+
+  def split_model
+    Split.find_by(name: split)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
 
       namespace :migrations do
         resource :app_feature_completion
+        resource :app_remote_kill
       end
     end
   end

--- a/db/migrate/20190413210327_rekey_app_remote_kills.rb
+++ b/db/migrate/20190413210327_rekey_app_remote_kills.rb
@@ -1,0 +1,26 @@
+class RekeyAppRemoteKills < ActiveRecord::Migration[5.1]
+  def change
+    create_table :better_app_remote_kills, id: :uuid, default: -> { "uuid_generate_v4()" } do |t|
+      t.references :app, type: :uuid, null: false, foreign_key: true
+      t.references :split, type: :uuid, null: false, foreign_key: true
+      t.string "reason", null: false
+      t.string "override_to", null: false
+      t.integer "first_bad_version", array: true, null: false
+      t.integer "fixed_version", array: true
+      t.timestamps
+
+      t.index ["split_id", "app_id", "reason"], unique: true
+    end
+
+    execute <<~SQL
+      insert into better_app_remote_kills
+      (app_id, split_id, reason, override_to, first_bad_Version, fixed_version, created_at, updated_at)
+      select app_id, split_id, reason, override_to, first_bad_version, fixed_version, created_at, updated_at
+      from app_remote_kills
+    SQL
+
+    drop_table :app_remote_kills
+
+    rename_table :better_app_remote_kills, :app_remote_kills
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190413110639) do
+ActiveRecord::Schema.define(version: 20190413210327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,7 +48,7 @@ ActiveRecord::Schema.define(version: 20190413110639) do
     t.index ["feature_gate_id"], name: "index_app_feature_completions_on_feature_gate_id"
   end
 
-  create_table "app_remote_kills", force: :cascade do |t|
+  create_table "app_remote_kills", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "app_id", null: false
     t.uuid "split_id", null: false
     t.string "reason", null: false

--- a/doc/arch/adr-001.md
+++ b/doc/arch/adr-001.md
@@ -1,0 +1,44 @@
+# ADR 001: AppRemoteKill Will Loosely Couple to Override Variant
+
+## Context
+
+Splits are accessible to any app in the same ecosystem, but not always
+defined by within that app.
+
+Increasingly, migrations may not be validated centrally in local
+development ecosystems as we build out a standalone migration runner,
+and there's no guarantee that all apps in an ecosystem will be up to
+date, so forcing central validation could introduce significant
+developer friction.
+
+Therefor it is unlikely that we could strongly valiate the variants
+of split that was defined by another app at the time that an
+app_remote_kill is created.
+
+Also, such validations, if they're only possible in production, could
+lead to broken migrations in production that are already applied in
+other ecosystems.
+
+## Decision
+
+We will not validate the override_to value of an AppRemoteKill against
+the split. The registry knock-out will simply no-op at runtime if the
+chosen variant is not available, allowing the team to quickly ship another
+migration to disable the feature.
+
+At this time, we will still strongly couple app_remote_kills to split
+existence, however. This may change in the future if it proves to cause
+operational issues
+
+## Status
+
+Accepted
+
+## Consequences
+
+The only remaining way to ship an AppRemoteKill that doesn't apply
+correctly in production would be to misspell the split name itself.
+
+We'll see whether that is acceptable or whether we should walk further
+down the decoupling path and make AppRemoteKills and
+AppFeatureCompletions entirely soft-coupled to splits by name.

--- a/spec/controllers/api/v2/migrations/app_remote_kills_controller_spec.rb
+++ b/spec/controllers/api/v2/migrations/app_remote_kills_controller_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::Migrations::AppRemoteKillsController do
+  let(:feature_gate) { FactoryBot.create(:feature_gate) }
+  let(:app) { FactoryBot.create(:app) }
+
+  describe "#create" do
+    it "is unauthorized with bad auth" do
+      http_authenticate username: app.name, auth_secret: 'bad bad bad'
+      post :create, as: :json
+      expect(response).to have_http_status :unauthorized
+    end
+
+    it "persists with a well-formed request" do
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: {
+        split: feature_gate.name,
+        reason: "my_bug_2019",
+        override_to: "false",
+        first_bad_version: "1.0",
+        fixed_version: "1.1"
+      }, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      result = app.remote_kills.first
+      expect(result.split).to eq(feature_gate)
+      expect(result.reason).to eq("my_bug_2019")
+      expect(result.override_to).to eq("false")
+      expect(result.first_bad_version).to eq(AppVersion.new("1.0"))
+      expect(result.fixed_version).to eq(AppVersion.new("1.1"))
+    end
+
+    it "updates an existing feature completion with a well-formed request" do
+      remote_kill = FactoryBot.create(:app_remote_kill, app: app, split: feature_gate, first_bad_version: "1.0", fixed_version: nil)
+
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: {
+        split: feature_gate.name,
+        reason: remote_kill.reason,
+        override_to: "false",
+        first_bad_version: "0.9",
+        fixed_version: "1.1"
+      }, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      remote_kill.reload
+      expect(remote_kill.first_bad_version).to eq(AppVersion.new("0.9"))
+      expect(remote_kill.fixed_version).to eq(AppVersion.new("1.1"))
+    end
+
+    it "nulls fixed_version with a null version via JSON request" do
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: {
+        split: feature_gate.name,
+        reason: "big_bug",
+        override_to: "false",
+        first_bad_version: "0.9",
+        fixed_version: nil
+      }, as: :json
+
+      expect(response).to have_http_status(:no_content)
+      result = app.remote_kills.first
+      expect(result.fixed_version).to eq(nil)
+    end
+
+    it "nulls fixed_version via a URLENCODED request" do
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: {
+        split: feature_gate.name,
+        reason: "big_bug",
+        override_to: "false",
+        first_bad_version: "0.9",
+        fixed_version: nil
+      }
+
+      expect(response).to have_http_status(:no_content)
+      result = app.remote_kills.first
+      expect(result.fixed_version).to eq(nil)
+    end
+
+    it "is invalid with a bad reason" do
+      http_authenticate username: app.name, auth_secret: app.auth_secret
+      post :create, params: {
+        split: feature_gate.name,
+        reason: "noWayJose",
+        override_to: "false",
+        first_bad_version: "1.0",
+        fixed_version: "1.1"
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response_json['errors']['reason'].first).to include("alphanumeric snake_case")
+    end
+  end
+end

--- a/spec/factories/app_remote_kills.rb
+++ b/spec/factories/app_remote_kills.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     app
     split
     sequence(:reason) { |n| "bug_#{n}" }
-    override_to { "touch_this" }
+    override_to { split.registry.keys.first }
     first_bad_version { "1.0" }
     fixed_version { nil }
   end

--- a/spec/models/app_remote_kill_migration_spec.rb
+++ b/spec/models/app_remote_kill_migration_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe AppRemoteKillMigration do
+  let(:app) { FactoryBot.create(:app) }
+  let(:feature_gate) { FactoryBot.create(:feature_gate) }
+  let(:experiment) { FactoryBot.create(:experiment) }
+
+  it "creates AppRemoteKills" do
+    subject = described_class.new(
+      app: app,
+      split: feature_gate.name,
+      reason: "my_giant_bug_2019",
+      override_to: "false",
+      first_bad_version: "1.0",
+      fixed_version: nil
+    )
+
+    expect(subject.save).to eq true
+
+    result = app.remote_kills.first
+    expect(result.split).to eq(feature_gate)
+    expect(result.reason).to eq("my_giant_bug_2019")
+    expect(result.override_to).to eq("false")
+    expect(result.first_bad_version).to eq(AppVersion.new("1.0"))
+    expect(result.fixed_version).to eq(nil)
+  end
+
+  it "updates existing AppRemoteKills" do
+    remote_kill = FactoryBot.create(
+      :app_remote_kill,
+      app: app,
+      split: feature_gate,
+      reason: "my_giant_bug_2019",
+      override_to: "false",
+      first_bad_version: "0.9",
+      fixed_version: nil
+    )
+    subject = described_class.new(
+      app: app,
+      split: feature_gate.name,
+      reason: "my_giant_bug_2019",
+      override_to: "false",
+      first_bad_version: "0.9",
+      fixed_version: "1.0"
+    )
+
+    expect(subject.save).to eq true
+
+    remote_kill.reload
+    expect(remote_kill.fixed_version).to eq(AppVersion.new("1.0"))
+  end
+
+  it "nullifies fixed_version with an empty string for URLEncoded compatibility" do
+    subject = described_class.new(
+      app: app,
+      split: feature_gate.name,
+      reason: "my_giant_bug_2019",
+      override_to: "false",
+      first_bad_version: "0.9",
+      fixed_version: ""
+    )
+
+    expect(subject.save).to eq true
+
+    result = app.remote_kills.first
+    expect(result.fixed_version).to eq(nil)
+  end
+
+  it "is invalid with no split" do
+    subject = described_class.new(
+      app: app,
+      split: "nonexistant_split",
+      reason: "my_giant_bug_2019",
+      override_to: "false",
+      first_bad_version: "0.9",
+      fixed_version: ""
+    )
+
+    expect(subject).to have(1).error_on(:split)
+    expect(subject.save).to eq false
+  end
+
+  it "is invalid with no reason" do
+    subject = described_class.new(
+      app: app,
+      split: feature_gate.name,
+      reason: "",
+      override_to: "false",
+      first_bad_version: "1.0",
+      fixed_version: nil
+    )
+
+    expect(subject).to have(1).error_on(:reason)
+    expect(subject.save).to eq false
+  end
+
+  it "is invalid with a nonexistant override_to" do
+    subject = described_class.new(
+      app: app,
+      split: feature_gate.name,
+      reason: "my_giant_bug_2019",
+      override_to: "not_it",
+      first_bad_version: "1.0",
+      fixed_version: nil
+    )
+
+    expect(subject).to have(1).error_on(:override_to)
+    expect(subject.save).to eq false
+  end
+
+  it "blows up with no app" do
+    expect {
+      described_class.new(
+        app: nil,
+        split: feature_gate.name,
+        reason: "my_giant_bug_2019",
+        override_to: "false",
+        first_bad_version: "1.0",
+        fixed_version: nil
+      )
+    }.to raise_error(/Must provide app/)
+  end
+end

--- a/spec/models/app_remote_kill_migration_spec.rb
+++ b/spec/models/app_remote_kill_migration_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe AppRemoteKillMigration do
   end
 
   it "is invalid with no reason on delete" do
+    FactoryBot.create(:app_remote_kill, app: app, split: feature_gate)
     subject = described_class.new(
       app: app,
       split: feature_gate.name,
@@ -168,6 +169,7 @@ RSpec.describe AppRemoteKillMigration do
 
     expect(subject).to have(1).error_on(:reason)
     expect(subject.save).to eq false
+    expect(app.remote_kills.count).to eq(1)
   end
 
   it "blows up with no app" do

--- a/spec/models/app_remote_kill_migration_spec.rb
+++ b/spec/models/app_remote_kill_migration_spec.rb
@@ -94,20 +94,6 @@ RSpec.describe AppRemoteKillMigration do
     expect(subject.save).to eq false
   end
 
-  it "is invalid with a nonexistant override_to" do
-    subject = described_class.new(
-      app: app,
-      split: feature_gate.name,
-      reason: "my_giant_bug_2019",
-      override_to: "not_it",
-      first_bad_version: "1.0",
-      fixed_version: nil
-    )
-
-    expect(subject).to have(1).error_on(:override_to)
-    expect(subject.save).to eq false
-  end
-
   it "blows up with no app" do
     expect {
       described_class.new(

--- a/spec/models/app_remote_kill_spec.rb
+++ b/spec/models/app_remote_kill_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe AppRemoteKill do
     expect(subject).to have(1).error_on(:reason)
   end
 
-  it "is invalid with an invalid variant" do
-    subject = FactoryBot.build(:app_remote_kill, override_to: :nonexistant)
-
-    expect(subject).to have(1).error_on(:override_to)
-  end
-
   it "is valid with nil fixed_version" do
     subject = FactoryBot.build(:app_remote_kill, first_bad_version: "1.0", fixed_version: nil)
 

--- a/spec/models/app_remote_kill_spec.rb
+++ b/spec/models/app_remote_kill_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe AppRemoteKill do
     expect(FactoryBot.build(:app_remote_kill)).to be_valid
   end
 
+  it "is invalid with misformatted reason" do
+    subject = FactoryBot.build(:app_remote_kill, reason: "SimplyTheBest")
+    expect(subject).to have(1).error_on(:reason)
+  end
+
   it "is invalid with an invalid variant" do
     subject = FactoryBot.build(:app_remote_kill, override_to: :nonexistant)
 

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -443,7 +443,7 @@ RSpec.describe Split, type: :model do
       end
 
       it "overrides to 100% remote_kill_override_to if remote killed" do
-        fc = FactoryBot.create(:app_remote_kill, split: subject, first_bad_version: "0.9", fixed_version: "1.1")
+        fc = FactoryBot.create(:app_remote_kill, split: subject, override_to: "touch_this", first_bad_version: "0.9", fixed_version: "1.1")
         app_build = fc.app.define_build(built_at: Time.zone.now, version: "1.0")
 
         subject_with_knockouts = Split.for_app_build(app_build).find(subject.id)


### PR DESCRIPTION
### Summary

just like #108 only for remote_kills.

Will call out relevant diff below.

/domain @Betterment/test_track_core 
/platform @samandmoore @smudge 