### PR TITLE
Mobile client endpoints

### DIFF
--- a/app/controllers/api/v1/app_identifier_visitor_configs_controller.rb
+++ b/app/controllers/api/v1/app_identifier_visitor_configs_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::AppIdentifierVisitorConfigsController < UnauthenticatedApiController
+  include CorsSupport
+
+  def show
+    app_build = AppVersionBuildPath.new(build_params).app_build
+    @active_splits = Split.for_presentation(app_build: app_build)
+    visitor = VisitorLookup.new(identifier_params).visitor
+    @visitor = visitor.id
+    @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
+  end
+
+  private
+
+  def build_params
+    params.permit(:app_name, :version_number, :build_timestamp)
+  end
+
+  def identifier_params
+    params.permit(:identifier_type_name, :identifier_value)
+  end
+end

--- a/app/controllers/api/v1/app_identifier_visitor_configs_controller.rb
+++ b/app/controllers/api/v1/app_identifier_visitor_configs_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::AppIdentifierVisitorConfigsController < UnauthenticatedApiControl
     app_build = AppVersionBuildPath.new(build_params).app_build
     @active_splits = Split.for_presentation(app_build: app_build)
     visitor = VisitorLookup.new(identifier_params).visitor
-    @visitor = visitor.id
+    @visitor_id = visitor.id
     @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
   end
 

--- a/app/controllers/api/v1/app_identifier_visitor_configs_controller.rb
+++ b/app/controllers/api/v1/app_identifier_visitor_configs_controller.rb
@@ -1,12 +1,17 @@
 class Api::V1::AppIdentifierVisitorConfigsController < UnauthenticatedApiController
   include CorsSupport
 
-  def show
-    app_build = AppVersionBuildPath.new(build_params).app_build
-    @active_splits = Split.for_presentation(app_build: app_build)
-    visitor = VisitorLookup.new(identifier_params).visitor
-    @visitor_id = visitor.id
-    @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
+  def show # rubocop:disable Metrics/AbcSize
+    build_path = AppVersionBuildPath.new(build_params)
+    if build_path.valid?
+      app_build = AppVersionBuildPath.new(build_params).app_build
+      @active_splits = Split.for_presentation(app_build: app_build)
+      visitor = VisitorLookup.new(identifier_params).visitor
+      @visitor_id = visitor.id
+      @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
+    else
+      render_errors build_path
+    end
   end
 
   private

--- a/app/controllers/api/v1/app_visitor_configs_controller.rb
+++ b/app/controllers/api/v1/app_visitor_configs_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::AppVisitorConfigsController < UnauthenticatedApiController
+  include CorsSupport
+
+  def show
+    app_build = AppVersionBuildPath.new(build_params).app_build
+    @active_splits = Split.for_presentation(app_build: app_build)
+    @visitor_id = visitor_id
+    visitor = Visitor.find_or_initialize_by(id: @visitor_id)
+    @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
+  end
+
+  private
+
+  def build_params
+    params.permit(:app_name, :version_number, :build_timestamp)
+  end
+
+  def visitor_id
+    params.permit(:visitor_id).fetch(:visitor_id)
+  end
+end

--- a/app/controllers/api/v1/app_visitor_configs_controller.rb
+++ b/app/controllers/api/v1/app_visitor_configs_controller.rb
@@ -2,11 +2,16 @@ class Api::V1::AppVisitorConfigsController < UnauthenticatedApiController
   include CorsSupport
 
   def show
-    app_build = AppVersionBuildPath.new(build_params).app_build
-    @active_splits = Split.for_presentation(app_build: app_build)
-    @visitor_id = visitor_id
-    visitor = Visitor.find_or_initialize_by(id: @visitor_id)
-    @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
+    build_path = AppVersionBuildPath.new(build_params)
+    if build_path.valid?
+      app_build = AppVersionBuildPath.new(build_params).app_build
+      @active_splits = Split.for_presentation(app_build: app_build)
+      @visitor_id = visitor_id
+      visitor = Visitor.find_or_initialize_by(id: @visitor_id)
+      @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
+    else
+      render_errors build_path
+    end
   end
 
   private

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -28,7 +28,7 @@ class App < ActiveRecord::Base
     def initialize(app_id:, version:, built_at:)
       @app_id = app_id
       @version = AppVersion.new(version)
-      @built_at = built_at
+      @built_at = built_at.is_a?(String) ? Time.zone.parse(built_at) : built_at
     end
   end
 end

--- a/app/models/app_version_build_path.rb
+++ b/app/models/app_version_build_path.rb
@@ -1,19 +1,46 @@
 class AppVersionBuildPath
-  attr_reader :app_name, :version, :built_at
+  include ActiveModel::Validations
+
+  attr_reader :app_name, :version_number, :build_timestamp
+
+  validates :app_name, :version_number, :build_timestamp, presence: true
+  # We want to make sure the client is shipping us high-precision ISO
+  # timestamps so we choose to allow timestamps at either millisecond or second
+  # precision based on the W3C interpretation of iso8601 from this SO answer:
+  #
+  # https://stackoverflow.com/a/3143231
+  validates :build_timestamp, format: {
+    with: /\A\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(.\d+)?([+-][0-2]\d:[0-5]\d|Z)\z/, allow_blank: true
+  }
+  validate :version_number_must_be_parseable
 
   def initialize(params)
     @app_name = params[:app_name]
-    @version = params[:version_number]
-    @built_at = params[:build_timestamp]
+    @version_number = params[:version_number]
+    @build_timestamp = params[:build_timestamp]
   end
 
   def app_build
-    @app_build ||= app.define_build(version: version, built_at: built_at)
+    @app_build ||= begin
+      raise "must be valid before retreiving app_build" unless valid?
+
+      app.define_build(version: version_number, built_at: build_timestamp)
+    end
   end
 
   private
 
   def app
     App.find_by!(name: app_name)
+  end
+
+  def version_number_must_be_parseable
+    return if version_number.blank?
+
+    AppVersion.new(version_number)
+  rescue StandardError
+    errors.add(:version_number, <<~ERROR)
+      must be a valid in alignment with https://github.com/Betterment/test_track/blob/master/app/models/app_version.rb
+    ERROR
   end
 end

--- a/app/models/app_version_build_path.rb
+++ b/app/models/app_version_build_path.rb
@@ -1,0 +1,19 @@
+class AppVersionBuildPath
+  attr_reader :app_name, :version, :built_at
+
+  def initialize(params)
+    @app_name = params[:app_name]
+    @version = params[:version_number]
+    @built_at = params[:build_timestamp]
+  end
+
+  def app_build
+    @app_build ||= app.define_build(version: version, built_at: built_at)
+  end
+
+  private
+
+  def app
+    App.find_by!(name: app_name)
+  end
+end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -6,6 +6,10 @@ class Visitor < ActiveRecord::Base
 
   validates :id, format: UUID_REGEX, allow_nil: true
 
+  def assignments_for(app_build)
+    Assignment.where(visitor: self).for_presentation(app_build: app_build)
+  end
+
   def assignment_registry
     assignments.to_hash
   end

--- a/app/views/api/v1/app_identifier_visitor_configs/show.json.jbuilder
+++ b/app/views/api/v1/app_identifier_visitor_configs/show.json.jbuilder
@@ -1,0 +1,4 @@
+json.partial! 'api/v1/app_visitor_configs/show',
+  active_splits: @active_splits,
+  visitor_id: @visitor_id,
+  assignments: @assignments

--- a/app/views/api/v1/app_visitor_configs/_show.json.jbuilder
+++ b/app/views/api/v1/app_visitor_configs/_show.json.jbuilder
@@ -1,0 +1,10 @@
+json.splits do
+  active_splits.each do |split|
+    json.set! split.name, split.registry
+  end
+end
+
+json.visitor do
+  json.id visitor_id
+  json.assignments assignments, :split_name, :variant, :context, :unsynced
+end

--- a/app/views/api/v1/app_visitor_configs/show.json.jbuilder
+++ b/app/views/api/v1/app_visitor_configs/show.json.jbuilder
@@ -1,0 +1,4 @@
+json.partial! 'api/v1/app_visitor_configs/show',
+  active_splits: @active_splits,
+  visitor_id: @visitor_id,
+  assignments: @assignments

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,21 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :apps, only: [], param: :name do
+        resources :versions, only: [], param: :number, constraints: { number: /[\d\.]+/ } do
+          resources :builds, only: [], param: :timestamp do
+            resources :visitors, only: [] do
+              resource :config, only: :show, controller: 'app_visitor_configs'
+            end
+            resources :identifier_types, only: [], param: :name do
+              resources :identifiers, only: [], param: :value do
+                resource :visitor_config, only: :show, controller: 'app_identifier_visitor_configs'
+              end
+            end
+          end
+        end
+      end
+
       # Shared secret-based assignment override for chrome extension
       match 'assignment_override', to: '/api/v1/cors#allow', via: :options
       resource :assignment_override, only: :create

--- a/spec/controllers/api/v1/app_identifier_visitor_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/app_identifier_visitor_configs_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Api::V1::AppIdentifierVisitorConfigsController do
 
       expect(response).to have_http_status :ok
       expect(response_json['splits']['blab_enabled']).to eq('false' => 50, 'true' => 50)
+      expect(response_json['visitor']['id']).to eq(visitor.id)
       expect(response_json['visitor']['assignments'].first['split_name']).to eq('blab_enabled')
       expect(response_json['visitor']['assignments'].first['variant']).to eq('true')
     end

--- a/spec/controllers/api/v1/app_identifier_visitor_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/app_identifier_visitor_configs_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::AppIdentifierVisitorConfigsController do
+  describe "#show" do
+    let(:app) { FactoryBot.create(:app) }
+    let(:identifier_type) { FactoryBot.create(:identifier_type, name: "clown_id") }
+    let(:feature_gate) { FactoryBot.create(:feature_gate, name: "blab_enabled", registry: { false: 50, true: 50 }) }
+    let(:visitor) { FactoryBot.create(:visitor) }
+    let(:identifier) { FactoryBot.create(:identifier, visitor: visitor) }
+
+    it "has knocked-out weightings and it doesn't include a non-force assignment for a feature gate that isn't feature complete" do
+      FactoryBot.create(
+        :assignment,
+        visitor: visitor,
+        split: feature_gate,
+        variant: "true",
+        context: "the_context",
+        mixpanel_result: "success"
+      )
+
+      get :show, params: {
+        app_name: app.name,
+        version_number: "1.0",
+        build_timestamp: "2019-01-01",
+        identifier_type_name: identifier.identifier_type.name,
+        identifier_value: identifier.value
+      }
+
+      expect(response).to have_http_status :ok
+      expect(response_json['splits']['blab_enabled']).to eq('false' => 100, 'true' => 0)
+      expect(response_json['visitor']['assignments']).to be_empty
+    end
+
+    it "has real weightings and it includes a non-force assignment for a feature gate that is feature complete" do
+      FactoryBot.create(
+        :assignment,
+        visitor: visitor,
+        split: feature_gate,
+        variant: "true",
+        context: "the_context",
+        mixpanel_result: "success"
+      )
+
+      FactoryBot.create(
+        :app_feature_completion,
+        feature_gate: feature_gate,
+        app: app,
+        version: "0.1"
+      )
+
+      get :show, params: {
+        app_name: app.name,
+        version_number: "1.0",
+        build_timestamp: "2019-01-01",
+        identifier_type_name: identifier.identifier_type.name,
+        identifier_value: identifier.value
+      }
+
+      expect(response).to have_http_status :ok
+      expect(response_json['splits']['blab_enabled']).to eq('false' => 50, 'true' => 50)
+      expect(response_json['visitor']['assignments'].first['split_name']).to eq('blab_enabled')
+      expect(response_json['visitor']['assignments'].first['variant']).to eq('true')
+    end
+  end
+end

--- a/spec/controllers/api/v1/app_identifier_visitor_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/app_identifier_visitor_configs_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::AppIdentifierVisitorConfigsController do
       get :show, params: {
         app_name: app.name,
         version_number: "1.0",
-        build_timestamp: "2019-01-01",
+        build_timestamp: "2019-04-16T14:35:30Z",
         identifier_type_name: identifier.identifier_type.name,
         identifier_value: identifier.value
       }
@@ -51,7 +51,7 @@ RSpec.describe Api::V1::AppIdentifierVisitorConfigsController do
       get :show, params: {
         app_name: app.name,
         version_number: "1.0",
-        build_timestamp: "2019-01-01",
+        build_timestamp: "2019-04-16T14:35:30Z",
         identifier_type_name: identifier.identifier_type.name,
         identifier_value: identifier.value
       }
@@ -61,6 +61,18 @@ RSpec.describe Api::V1::AppIdentifierVisitorConfigsController do
       expect(response_json['visitor']['id']).to eq(visitor.id)
       expect(response_json['visitor']['assignments'].first['split_name']).to eq('blab_enabled')
       expect(response_json['visitor']['assignments'].first['variant']).to eq('true')
+    end
+
+    it "returns unprocessable_entity if the app_build url params are invalid" do
+      get :show, params: {
+        app_name: app.name,
+        version_number: "01.0",
+        build_timestamp: "2019-04-16T14:35:30Z",
+        identifier_type_name: identifier.identifier_type.name,
+        identifier_value: identifier.value
+      }
+
+      expect(response).to have_http_status :unprocessable_entity
     end
   end
 end

--- a/spec/controllers/api/v1/app_visitor_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/app_visitor_configs_controller_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Api::V1::AppVisitorConfigsController do
   describe "#show" do
     let(:app) { FactoryBot.create(:app) }
-    let(:identifier_type) { FactoryBot.create(:identifier_type, name: "clown_id") }
     let(:feature_gate) { FactoryBot.create(:feature_gate, name: "blab_enabled", registry: { false: 50, true: 50 }) }
     let(:visitor) { FactoryBot.create(:visitor) }
 

--- a/spec/controllers/api/v1/app_visitor_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/app_visitor_configs_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Api::V1::AppVisitorConfigsController do
       get :show, params: {
         app_name: app.name,
         version_number: "1.0",
-        build_timestamp: "2019-01-01",
+        build_timestamp: "2019-04-16T14:35:30Z",
         visitor_id: visitor.id
       }
 
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::AppVisitorConfigsController do
       get :show, params: {
         app_name: app.name,
         version_number: "1.0",
-        build_timestamp: "2019-01-01",
+        build_timestamp: "2019-04-16T14:35:30Z",
         visitor_id: visitor.id
       }
 
@@ -56,6 +56,17 @@ RSpec.describe Api::V1::AppVisitorConfigsController do
       expect(response_json['splits']['blab_enabled']).to eq('false' => 50, 'true' => 50)
       expect(response_json['visitor']['assignments'].first['split_name']).to eq('blab_enabled')
       expect(response_json['visitor']['assignments'].first['variant']).to eq('true')
+    end
+
+    it "returns unprocessable_entity if the app_build url params are invalid" do
+      get :show, params: {
+        app_name: app.name,
+        version_number: "01.0",
+        build_timestamp: "2019-04-16T14:35:30Z",
+        visitor_id: visitor.id
+      }
+
+      expect(response).to have_http_status :unprocessable_entity
     end
   end
 end

--- a/spec/controllers/api/v1/app_visitor_configs_controller_spec.rb
+++ b/spec/controllers/api/v1/app_visitor_configs_controller_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::AppVisitorConfigsController do
+  describe "#show" do
+    let(:app) { FactoryBot.create(:app) }
+    let(:identifier_type) { FactoryBot.create(:identifier_type, name: "clown_id") }
+    let(:feature_gate) { FactoryBot.create(:feature_gate, name: "blab_enabled", registry: { false: 50, true: 50 }) }
+    let(:visitor) { FactoryBot.create(:visitor) }
+
+    it "has knocked-out weightings and it doesn't include a non-force assignment for a feature gate that isn't feature complete" do
+      FactoryBot.create(
+        :assignment,
+        visitor: visitor,
+        split: feature_gate,
+        variant: "true",
+        context: "the_context",
+        mixpanel_result: "success"
+      )
+
+      get :show, params: {
+        app_name: app.name,
+        version_number: "1.0",
+        build_timestamp: "2019-01-01",
+        visitor_id: visitor.id
+      }
+
+      expect(response).to have_http_status :ok
+      expect(response_json['splits']['blab_enabled']).to eq('false' => 100, 'true' => 0)
+      expect(response_json['visitor']['assignments']).to be_empty
+    end
+
+    it "has real weightings and it includes a non-force assignment for a feature gate that is feature complete" do
+      FactoryBot.create(
+        :assignment,
+        visitor: visitor,
+        split: feature_gate,
+        variant: "true",
+        context: "the_context",
+        mixpanel_result: "success"
+      )
+
+      FactoryBot.create(
+        :app_feature_completion,
+        feature_gate: feature_gate,
+        app: app,
+        version: "0.1"
+      )
+
+      get :show, params: {
+        app_name: app.name,
+        version_number: "1.0",
+        build_timestamp: "2019-01-01",
+        visitor_id: visitor.id
+      }
+
+      expect(response).to have_http_status :ok
+      expect(response_json['splits']['blab_enabled']).to eq('false' => 50, 'true' => 50)
+      expect(response_json['visitor']['assignments'].first['split_name']).to eq('blab_enabled')
+      expect(response_json['visitor']['assignments'].first['variant']).to eq('true')
+    end
+  end
+end

--- a/spec/models/app_version_build_path_spec.rb
+++ b/spec/models/app_version_build_path_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+describe AppVersionBuildPath do
+  it "is valid with valid args" do
+    expect(
+      described_class.new(
+        app_name: "my_app",
+        version_number: "1.0",
+        build_timestamp: "2019-04-16T14:35:30Z"
+      )
+    ).to be_valid
+  end
+
+  it "is invalid with no app_name" do
+    expect(
+      described_class.new(
+        app_name: "",
+        version_number: "1.0",
+        build_timestamp: "2019-04-16T14:35:30Z"
+      )
+    ).to have(1).error_on(:app_name)
+  end
+
+  it "is invalid with no version_number" do
+    expect(
+      described_class.new(
+        app_name: "my_app",
+        version_number: "",
+        build_timestamp: "2019-04-16T14:35:30Z"
+      )
+    ).to have(1).error_on(:version_number)
+  end
+
+  it "is invalid with no build timestamp" do
+    expect(
+      described_class.new(
+        app_name: "my_app",
+        version_number: "1.0",
+        build_timestamp: ""
+      )
+    ).to have(1).error_on(:build_timestamp)
+  end
+
+  it "is invalid with an illegal version number" do
+    expect(
+      described_class.new(
+        app_name: "my_app",
+        version_number: "01.0",
+        build_timestamp: "2019-04-16T14:35:30Z"
+      )
+    ).to have(1).error_on(:version_number)
+  end
+
+  it "is invalid with a non-ISO date" do
+    expect(
+      described_class.new(
+        app_name: "my_app",
+        version_number: "1.0",
+        build_timestamp: "2019-04-16 10:38:08 -0400"
+      )
+    ).to have(1).error_on(:build_timestamp)
+  end
+
+  it "is valid with an ISO date with millis" do
+    expect(
+      described_class.new(
+        app_name: "my_app",
+        version_number: "1.0",
+        build_timestamp: "2019-04-16T14:35:30.123Z"
+      )
+    ).to be_valid
+  end
+
+  it "is invalid with an ISO date without seconds" do
+    expect(
+      described_class.new(
+        app_name: "my_app",
+        version_number: "1.0",
+        build_timestamp: "2019-04-16T14:35Z"
+      )
+    ).to have(1).error_on(:build_timestamp)
+  end
+
+  describe "#app_build" do
+    it "will not allow retrieval when invalid" do
+      expect {
+        described_class.new(
+          app_name: "",
+          version_number: "",
+          build_timestamp: ""
+        ).app_build
+      }.to raise_error(/must be valid/)
+    end
+
+    it "is valid with a found app" do
+      app = FactoryBot.create(:app, name: "my_app")
+
+      app_build = described_class.new(
+        app_name: "my_app",
+        version_number: "1.0",
+        build_timestamp: "2019-04-16T14:35:30Z"
+      ).app_build
+
+      expect(app_build.app_id).to eq(app.id)
+      expect(app_build.version).to eq(AppVersion.new("1.0"))
+      expect(app_build.built_at).to eq(Time.zone.parse("2019-04-16T14:35:30Z"))
+    end
+
+    it "will throw ActiveRecord::RecordNotFound when app can't be found by name" do
+      expect {
+        described_class.new(
+          app_name: "my_app",
+          version_number: "1.0",
+          build_timestamp: "2019-04-16T14:35:30Z"
+        ).app_build
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Provides endpoints for clients in the field to filter assignments and do contextual variant knockouts.

I believe this will be the last TT PR before MVP of mobile extensions is done server side.

### Other Information

Per usual there's a bunch of commits in here that are not relevant due to stacked PRs. I'll call out the real diff below.

/domain @Betterment/test_track_core 
/domain @JonLz for mobile integration needs - this would be what you'd be implementing to client side.
/platform @samandmoore @smudge 
