### PR TITLE
Add split decisions controller

### DIFF
--- a/app/controllers/api/v2/migrations/split_decisions_controller.rb
+++ b/app/controllers/api/v2/migrations/split_decisions_controller.rb
@@ -1,0 +1,16 @@
+class Api::V2::Migrations::SplitDecisionsController < AuthenticatedApiController
+  def create
+    split_decision = SplitDecisionMigration.new(create_params.merge(app: current_app))
+    if split_decision.save
+      head :no_content
+    else
+      render_errors split_decision
+    end
+  end
+
+  private
+
+  def create_params
+    params.permit(:split, :variant)
+  end
+end

--- a/app/models/split_decision_migration.rb
+++ b/app/models/split_decision_migration.rb
@@ -1,0 +1,39 @@
+class SplitDecisionMigration
+  include ActiveModel::Validations
+
+  attr_reader :app,
+    :split,
+    :variant
+
+  validate :split_must_exist
+  validate :variant_must_exist
+
+  def initialize(params)
+    @app = params[:app] || raise("Must provide app")
+    @split = params[:split]
+    @variant = params[:variant]
+  end
+
+  def save
+    if valid?
+      split_model.create_decision!(variant: variant)
+      true
+    else
+      false
+    end
+  end
+
+  private
+
+  def split_model
+    @split_model ||= Split.find_by(owner_app: app, name: split)
+  end
+
+  def split_must_exist
+    errors.add(:split, "must exist and belong to app") unless split_model
+  end
+
+  def variant_must_exist
+    errors.add(:variant, "must exist in split") unless split_model&.has_variant?(variant)
+  end
+end

--- a/app/models/split_decision_migration.rb
+++ b/app/models/split_decision_migration.rb
@@ -34,6 +34,8 @@ class SplitDecisionMigration
   end
 
   def variant_must_exist
-    errors.add(:variant, "must exist in split") unless split_model&.has_variant?(variant)
+    return unless split_model
+
+    errors.add(:variant, "must exist in split") unless split_model.has_variant?(variant)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
             resource :app_remote_kill, only: :create
             resource :split, only: :create
             resource :split_retirement, only: :create
+            resource :split_decision, only: :create
           end
         end
       end

--- a/spec/controllers/api/v2/migrations/split_decisions_controller_spec.rb
+++ b/spec/controllers/api/v2/migrations/split_decisions_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Api::V2::Migrations::SplitDecisionsController do
+  let(:default_app) { FactoryBot.create :app, name: "default_app", auth_secret: "6Sd6T7T6Q8hKcoo0t8CTzV0IdN1EEHqXB2Ig4raZsOU" }
+  let!(:split) do
+    FactoryBot.create(:split, owner_app: default_app, name: "default_app.my_split", registry: { a: 100, b: 0 }, finished_at: Time.zone.now)
+  end
+
+  describe '#create' do
+    it "doesn't decide when unauthenticated" do
+      post :create, params: { split: 'default_app.my_split', variant: "b" }, as: :json
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(split.reload.finished_at).to be_present
+    end
+  end
+
+  describe "while authenticated" do
+    before do
+      http_authenticate username: default_app.name, auth_secret: default_app.auth_secret
+    end
+
+    describe '#create' do
+      it "decides a split to 100% desired weightings" do
+        post :create, params: { split: 'default_app.my_split', variant: "b" }, as: :json
+
+        expect(response).to have_http_status(:no_content)
+        split.reload
+        expect(split.registry).to eq 'a' => 0, 'b' => 100
+        expect(split.decided_at).to be_present
+        expect(split.finished_at).to eq nil
+      end
+
+      it 'returns errors when invalid' do
+        post :create, params: { split: 'default_app.my_split', variant: "not_it" }, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response_json['errors']['variant'].first).to include("exist")
+      end
+    end
+  end
+end

--- a/spec/models/split_decision_migration_spec.rb
+++ b/spec/models/split_decision_migration_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe SplitDecisionMigration do
+  it "retires a split" do
+    split = FactoryBot.create(:split, name: "my_split", registry: { a: 100, b: 0 }, finished_at: Time.zone.now)
+
+    expect(described_class.new(app: split.owner_app, split: "my_split", variant: "b").save).to eq true
+
+    split.reload
+    expect(split.finished_at).to be_nil
+    expect(split.decided_at).to be_present
+    expect(split.registry).to eq("a" => 0, "b" => 100)
+  end
+
+  it "blows up with no app" do
+    expect {
+      described_class.new(app: nil, split: "my_split", variant: "b")
+    }.to raise_error(/app/)
+  end
+
+  it "is invalid with a missing split" do
+    app = FactoryBot.create(:app)
+    expect(described_class.new(app: app, split: "my_split", variant: "b")).to have(1).error_on(:split)
+  end
+
+  it "is invalid with a split from the wrong app" do
+    FactoryBot.create(:split, name: "my_split", registry: { a: 100, b: 0 })
+    other_app = FactoryBot.create(:app)
+
+    expect(described_class.new(app: other_app, split: "my_split", variant: "b")).to have(1).error_on(:split)
+  end
+
+  it "is invalid with a missing variant" do
+    split = FactoryBot.create(:split, name: "my_split", registry: { a: 100, b: 0 })
+
+    expect(described_class.new(app: split.owner_app, split: "my_split", variant: "nope")).to have(1).error_on(:variant)
+  end
+end

--- a/spec/models/split_decision_migration_spec.rb
+++ b/spec/models/split_decision_migration_spec.rb
@@ -20,14 +20,18 @@ RSpec.describe SplitDecisionMigration do
 
   it "is invalid with a missing split" do
     app = FactoryBot.create(:app)
-    expect(described_class.new(app: app, split: "my_split", variant: "b")).to have(1).error_on(:split)
+    subject = described_class.new(app: app, split: "my_split", variant: "b")
+    expect(subject).to have(1).error_on(:split)
+    expect(subject).to have(0).errors_on(:variant)
   end
 
   it "is invalid with a split from the wrong app" do
     FactoryBot.create(:split, name: "my_split", registry: { a: 100, b: 0 })
     other_app = FactoryBot.create(:app)
 
-    expect(described_class.new(app: other_app, split: "my_split", variant: "b")).to have(1).error_on(:split)
+    subject = described_class.new(app: other_app, split: "my_split", variant: "b")
+    expect(subject).to have(1).error_on(:split)
+    expect(subject).to have(0).errors_on(:variant)
   end
 
   it "is invalid with a missing variant" do


### PR DESCRIPTION
### Summary

Adds a new migration endpoint for deciding splits from the new migration CLI. It's very similar to retirement except it actually unretires a split that has been retired. This expressive capability to be able to unretire a split back to a decided state is why it makes sense to even make this a migration, otherwise, it would be impossible to revert a retirement of a decided split without temporarily pivoting through active and clicking a button in the admin console.

/domain @Betterment/test_track_core 
/platform @samandmoore @smudge 
