### PR TITLE
Add sentry support, make airbrake optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: ruby
 rvm:
-- 2.4.2
-- 2.6.2
+  - 2.4.2
+  - 2.6.2
 addons:
   postgresql: '9.4'
 before_install:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - gem install bundler
 before_script:
-- psql -c 'create database test_track_test;' -U postgres
+  - psql -c 'create database test_track_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-- 2.3.1
 - 2.4.2
+- 2.6.2
 addons:
   postgresql: '9.4'
 before_install:

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,8 @@ gem 'responders'
 
 gem 'rack-timeout'
 
-gem 'airbrake', '~> 7.3.5'
+gem 'airbrake', '~> 7.3.5', require: false
+gem 'sentry-raven', require: false
 
 gem 'newrelic_rpm'
 gem 'ddtrace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,8 @@ GEM
       rubyzip (~> 1.0)
     semantic_logger (4.2.0)
       concurrent-ruby (~> 1.0)
+    sentry-raven (2.9.0)
+      faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simple_form (3.5.0)
@@ -447,6 +449,7 @@ DEPENDENCIES
   sass-rails
   sdoc (~> 0.4.0)
   selenium-webdriver
+  sentry-raven
   shoulda-matchers
   simple_form
   simplecov
@@ -461,4 +464,4 @@ DEPENDENCIES
   with_transactional_lock
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,8 @@ GEM
       msgpack
       opentracing (>= 0.4.1)
     debug_inspector (0.0.3)
-    delayed_job (4.1.3)
-      activesupport (>= 3.0, < 5.2)
+    delayed_job (4.1.5)
+      activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.2)
       activerecord (>= 3.0, < 5.2)
       delayed_job (>= 3.0, < 5)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,4 +1,6 @@
 if ENV['AIRBRAKE_API_KEY'].present?
+  require 'airbrake'
+
   Airbrake.configure do |config|
     config.project_id = ENV['AIRBRAKE_API_KEY']
     config.project_key = ENV['AIRBRAKE_API_KEY']

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,15 @@
+if ENV.key?('SENTRY_DSN')
+  require 'sentry-raven'
+
+  Raven.configure do |config|
+    additional_excluded_exceptions = %w(
+      ActionController::UnknownHttpMethod
+      ActionController::UnknownFormat
+      SignalException
+    )
+    config.excluded_exceptions += additional_excluded_exceptions
+    config.release = ENV['GIT_COMMIT'] if ENV.key?('GIT_COMMIT')
+
+    config.inspect_exception_causes_for_exclusion = true
+  end
+end


### PR DESCRIPTION
### Summary

Adds sentry support and makes Airbrake support optional (not requiring the gem if not needed).

/domain @Betterment/test_track_core 
/platform @samandmoore @aburgel
