### PR TITLE
Touch assignments to ensure chrome extension sees changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /public/system
 
 /spec/error_screenshots/
+/spec/examples.txt
 .idea
 /.powenv
 /.env.local

--- a/app/models/arbitrary_assignment_creation.rb
+++ b/app/models/arbitrary_assignment_creation.rb
@@ -1,8 +1,7 @@
 class ArbitraryAssignmentCreation
   attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context, :force
 
-  # rubocop:disable Metrics/ParameterLists
-  def initialize(
+  def initialize( # rubocop:disable Metrics/ParameterLists
     visitor_id: nil,
     split_name: nil,
     variant: nil,
@@ -19,7 +18,6 @@ class ArbitraryAssignmentCreation
     @context = context
     @force = force
   end
-  # rubocop:enable Metrics/ParameterLists
 
   def save!
     if superseding?
@@ -43,10 +41,10 @@ class ArbitraryAssignmentCreation
     save!
   end
 
-  def supersede!(now = Time.zone.now)
+  def supersede!
     assignment.with_lock do
       assignment.create_previous_assignment!(now)
-      assignment.update! supersede_attrs(now)
+      assignment.update! supersede_attrs
     end
   end
 
@@ -92,14 +90,14 @@ class ArbitraryAssignmentCreation
       mixpanel_result: mixpanel_result,
       bulk_assignment_id: bulk_assignment_id_for_save,
       context: context_for_save,
+      updated_at: now,
       force: force
     }
   end
 
-  def supersede_attrs(updated_at)
+  def supersede_attrs
     assignment_attrs.merge(
       individually_overridden: individual_override?,
-      updated_at: updated_at,
       bulk_assignment_id: bulk_assignment_id_for_supersession,
       context: context_for_supersession
     )
@@ -123,5 +121,9 @@ class ArbitraryAssignmentCreation
     else
       context_for_save
     end
+  end
+
+  def now
+    @now ||= Time.zone.now
   end
 end

--- a/spec/models/arbitrary_assignment_creation_spec.rb
+++ b/spec/models/arbitrary_assignment_creation_spec.rb
@@ -65,11 +65,13 @@ RSpec.describe ArbitraryAssignmentCreation, type: :model do
             split: split,
             variant: "variant1",
             bulk_assignment: bulk_assignment,
-            context: "bulk_assignment"
+            context: "bulk_assignment",
+            mixpanel_result: "success",
+            updated_at: Time.zone.parse('2019-01-01 00:00:00')
           )
         end
 
-        it "does nothing" do
+        it "maintains bulk assignment status" do
           expect { subject.save! }
             .not_to change { Assignment.count }
 
@@ -89,13 +91,17 @@ RSpec.describe ArbitraryAssignmentCreation, type: :model do
             visitor: visitor,
             split: split,
             variant: "variant1",
-            context: "context"
+            context: "context",
+            mixpanel_result: "success",
+            updated_at: Time.zone.parse('2019-01-01 00:00:00')
           )
         end
 
-        it "does nothing" do
-          expect { subject.save! }
-            .not_to change { Assignment.count }
+        it "touches the record but changes nothing else" do
+          Timecop.freeze(Time.zone.parse('2019-07-01 00:00:00')) do
+            expect { subject.save! }
+              .not_to change { Assignment.count }
+          end
 
           existing_assignment.reload
           expect(existing_assignment.variant).to eq "variant1"
@@ -103,6 +109,8 @@ RSpec.describe ArbitraryAssignmentCreation, type: :model do
           expect(existing_assignment.split).to eq split
           expect(existing_assignment.bulk_assignment).to eq nil
           expect(existing_assignment.context).to eq "context"
+          expect(existing_assignment.mixpanel_result).to eq "success"
+          expect(existing_assignment.updated_at).to eq Time.zone.parse('2019-07-01 00:00:00')
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,5 +10,7 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+
   config.order = :random
 end


### PR DESCRIPTION
/domain @Betterment/test_track_core 
/no-platform

This addresses a UX bug in the chrome extension.

For a decided, but still active, split where a previous assignment existed, using the chrome extension to assign the same variant effectively no-ops, which looks like nothing happens within the chrome extension. This makes it appear as if test track is broken.

How we get here is a little convoluted, but here are the important points:

1. Assigning to the same variant results in no change in the assignments table, including no change to the `updated_at` attribute.

2. For a decided split, assignments that were updated before the split's `decided_at` will not appear in the assignment registry.

3. Within the chrome extension, a split appears unassigned if there is no record in the assignment registry.

Using the chrome extension, if the user attempts to create an assignment when the database has an existing assignment for that variant, the updated_at attribute of the assignment will remain the unchanged, and the assignment will continue to appear "unassigned".

To fix, I'm always updating the `updated_at` regardless of whether the assignment actually changed. This should more closely match the user's expectation that using the chrome extension should "force" assignment changes.