### PR TITLE
Bugfix: Noop assignment_events for existing assignments

### DIFF
--- a/app/models/deterministic_assignment_creation.rb
+++ b/app/models/deterministic_assignment_creation.rb
@@ -34,7 +34,7 @@ class DeterministicAssignmentCreation
   end
 
   def existing_assignment
-    @existing_assignment ||= Assignment.find_by visitor: visitor, split: split
+    Assignment.find_by visitor: visitor, split: split
   end
 
   def visitor

--- a/app/models/deterministic_assignment_creation.rb
+++ b/app/models/deterministic_assignment_creation.rb
@@ -14,19 +14,15 @@ class DeterministicAssignmentCreation
   end
 
   def save!
-    unless split.feature_gate?
+    if !split.feature_gate? && !existing_assignment
       ArbitraryAssignmentCreation.create!(
         visitor_id: visitor_id,
         split_name: split_name,
-        variant: variant,
+        variant: variant_calculator.variant,
         mixpanel_result: mixpanel_result,
         context: context
       )
     end
-  end
-
-  def variant
-    assignment.variant || variant_calculator.variant
   end
 
   def variant_calculator
@@ -37,8 +33,8 @@ class DeterministicAssignmentCreation
     @split ||= Split.find_by!(name: split_name)
   end
 
-  def assignment
-    @assignment ||= Assignment.find_or_initialize_by visitor: visitor, split: split
+  def existing_assignment
+    @existing_assignment ||= Assignment.find_by visitor: visitor, split: split
   end
 
   def visitor

--- a/spec/controllers/api/v1/assignment_events_controller_spec.rb
+++ b/spec/controllers/api/v1/assignment_events_controller_spec.rb
@@ -30,8 +30,12 @@ RSpec.describe Api::V1::AssignmentEventsController, type: :controller do
     end
 
     it "noops if a conflicting assignment already exists" do
-      assignment = FactoryBot.create(:assignment, visitor: visitor, split: split, variant: "control")
+      assignment = nil
+      Timecop.freeze(1.year.ago) do
+        assignment = FactoryBot.create(:assignment, visitor: visitor, split: split, variant: "control")
+      end
 
+      assignment.reload
       original_attributes = assignment.attributes
 
       expect {

--- a/spec/controllers/api/v1/assignment_events_controller_spec.rb
+++ b/spec/controllers/api/v1/assignment_events_controller_spec.rb
@@ -30,13 +30,16 @@ RSpec.describe Api::V1::AssignmentEventsController, type: :controller do
     end
 
     it "noops if a conflicting assignment already exists" do
-      FactoryBot.create(:assignment, visitor: visitor, split: split, variant: "control")
+      assignment = FactoryBot.create(:assignment, visitor: visitor, split: split, variant: "control")
+
+      original_attributes = assignment.attributes
 
       expect {
         post :create, params: create_params
       }.not_to change { PreviousAssignment.count }
 
       expect(response).to have_http_status :no_content
+      expect(assignment.reload.attributes).to eq original_attributes
     end
 
     it "allows a request without a mixpanel_result" do

--- a/spec/models/deterministic_assignment_creation_spec.rb
+++ b/spec/models/deterministic_assignment_creation_spec.rb
@@ -55,13 +55,12 @@ RSpec.describe DeterministicAssignmentCreation, type: :model do
         .with(hash_including(variant: "variant2"))
     end
 
-    it "recreates with the previously assigned variant if already assigned" do
+    it "noops if already assigned" do
       FactoryBot.create(:assignment, split: split, visitor: Visitor.from_id("bc8833fd-1bdc-4751-a13c-8aba0ef95a3b"), variant: "variant3")
 
       subject.save!
 
-      expect(ArbitraryAssignmentCreation).to have_received(:create!)
-        .with(hash_including(variant: "variant3"))
+      expect(ArbitraryAssignmentCreation).not_to have_received(:create!)
     end
 
     it "creates with the same context" do


### PR DESCRIPTION
### Summary

#119 introduced a change that unintentionally caused the `assignment_event` endpoint to touch updated_at on existing assignments for decided splits when clients, seeing no assignment (due to assignment masking in the relatively-new decision logic) attempted to create fresh assignments. As a result, the old assignment would win over the decision, effectively negating the decision.

This only impacts experiments, as feature gates are already immune to being explicitly assigned via the `assignment_event` endpoint

### Other Information

I got to this implementation by testing from the outside in and redefining a test whose title matched what I wanted to be more strict. Ultimately it turns out that the `DeterministicAssignmentCreation` model was way fancier than it needed to be, unless I'm missing something.

DeterministicAssignmentCreation is only used by the AssignmentEvents controller, so the blast radius of this change, even if it is buggy, is contained. There's already a relatively nasty bug in play here, so my gut is to move aggressively here.

/domain @Betterment/test_track_core 
/platform @coreyja @samandmoore