### PR TITLE
Show decided state in admin

### DIFF
--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -157,10 +157,7 @@ class Split < ActiveRecord::Base
   end
 
   def decided_variant
-    return nil unless decided?
-    registry.each_with_object([]) { |(k, v), found|
-      found << k if v == 100
-    }.first
+    registry.key(100) if decided?
   end
 
   private

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -101,6 +101,10 @@ class Split < ActiveRecord::Base
     finished_at.present?
   end
 
+  def decided?
+    decided_at.present?
+  end
+
   def reassign_weight(weighting_registry)
     now = Time.zone.now
     previous_split_registries.build(registry: registry, created_at: updated_at, updated_at: now, superseded_at: now)

--- a/app/models/split.rb
+++ b/app/models/split.rb
@@ -156,6 +156,13 @@ class Split < ActiveRecord::Base
     @require_app_name_prefix
   end
 
+  def decided_variant
+    return nil unless decided?
+    registry.each_with_object([]) { |(k, v), found|
+      found << k if v == 100
+    }.first
+  end
+
   private
 
   def knock_out_weightings(registry_hash, to: "false")

--- a/app/views/admin/splits/_details.html.erb
+++ b/app/views/admin/splits/_details.html.erb
@@ -19,7 +19,13 @@
       </tr>
       <tr>
         <td>Status</td>
-        <td class="u-status--<%= @split.finished? ? 'finished' : 'active' %>"><%= @split.finished? ? 'Finished' : 'Active' %><span class="sc-p--s">🏁</span></td>
+        <% if @split.finished? %>
+               <td class="u-status--finished">Finished (retired)<span class="sc-p--s">🏁</span></td>
+        <% elsif @split.decided? %>
+               <td class="u-status--decided">Decided</td>
+        <% else %>
+               <td class="u-status--active">Active</td>
+        <% end %>
         <td>&nbsp;</td>
       </tr>
       <tr>

--- a/app/views/admin/splits/_details.html.erb
+++ b/app/views/admin/splits/_details.html.erb
@@ -28,7 +28,7 @@
         <% elsif @split.decided? %>
           <td class="u-status--decided">Decided (decision: <%= @split.decided_variant %>)</td>
         <% else %>
-               <td class="u-status--active">Active</td>
+          <td class="u-status--active">Active</td>
         <% end %>
         <td>&nbsp;</td>
       </tr>

--- a/app/views/admin/splits/_details.html.erb
+++ b/app/views/admin/splits/_details.html.erb
@@ -20,9 +20,13 @@
       <tr>
         <td>Status</td>
         <% if @split.finished? %>
-               <td class="u-status--finished">Finished (retired)<span class="sc-p--s">🏁</span></td>
+          <td class="u-status--finished">Finished (Retired)
+            <% if @split.decided? %>
+              (decision: <%= @split.decided_variant %>)
+           <% end %>
+           <span class="sc-p--s">🏁</span></td>
         <% elsif @split.decided? %>
-               <td class="u-status--decided">Decided</td>
+          <td class="u-status--decided">Decided (decision: <%= @split.decided_variant %>)</td>
         <% else %>
                <td class="u-status--active">Active</td>
         <% end %>

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -452,6 +452,25 @@ RSpec.describe Split, type: :model do
       end
     end
 
+    describe "#decided_variant" do
+      it "returns nil if 100% weighted and undecided" do
+        subject = FactoryBot.build_stubbed(:split, registry: { false: 100, true: 0 })
+
+        expect(subject.decided_variant).to be_nil
+      end
+
+      it "returns nil if decided and not 100% weighted" do
+        subject = FactoryBot.build_stubbed(:split, registry: { false: 50, true: 50 }, decided_at: Time.zone.now)
+
+        expect(subject.decided_variant).to be_nil
+      end
+
+      it "returns 100% weighted variant if decided" do
+        subject = FactoryBot.build_stubbed(:split, registry: { false: 0, true: 100 }, decided_at: Time.zone.now)
+        expect(subject.decided_variant).to eq("true")
+      end
+    end
+
     context "with a non-feature-gate" do
       subject { FactoryBot.create(:split, registry: { hammer_time: 50, touch_this: 50 }) }
 

--- a/spec/models/split_spec.rb
+++ b/spec/models/split_spec.rb
@@ -467,6 +467,7 @@ RSpec.describe Split, type: :model do
 
       it "returns 100% weighted variant if decided" do
         subject = FactoryBot.build_stubbed(:split, registry: { false: 0, true: 100 }, decided_at: Time.zone.now)
+
         expect(subject.decided_variant).to eq("true")
       end
     end


### PR DESCRIPTION
### Summary

fixes #122

### Other Information

There are no tests on this field, and I didn't add any, but the Active codepath actually covers the finished and decided conditionals via fallthru, so this would be hard to break unless the definitions of finished or decided changed.

/domain @Betterment/test_track_core 
