### PR TITLE
Update assignment when mixpanel result has changed

### DIFF
--- a/app/models/arbitrary_assignment_creation.rb
+++ b/app/models/arbitrary_assignment_creation.rb
@@ -1,5 +1,5 @@
 class ArbitraryAssignmentCreation
-  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context, :force
+  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context, :force, :updated_at
 
   def initialize( # rubocop:disable Metrics/ParameterLists
     visitor_id: nil,
@@ -8,7 +8,8 @@ class ArbitraryAssignmentCreation
     mixpanel_result: nil,
     bulk_assignment_id: nil,
     context: nil,
-    force: false
+    force: false,
+    updated_at: nil
   )
     @visitor_id = visitor_id
     @split_name = split_name
@@ -17,6 +18,7 @@ class ArbitraryAssignmentCreation
     @bulk_assignment_id = bulk_assignment_id
     @context = context
     @force = force
+    @updated_at = updated_at
   end
 
   def save!
@@ -90,7 +92,7 @@ class ArbitraryAssignmentCreation
       mixpanel_result: mixpanel_result,
       bulk_assignment_id: bulk_assignment_id_for_save,
       context: context_for_save,
-      updated_at: now,
+      updated_at: updated_at || now,
       force: force
     }
   end

--- a/app/models/deterministic_assignment_creation.rb
+++ b/app/models/deterministic_assignment_creation.rb
@@ -14,13 +14,14 @@ class DeterministicAssignmentCreation
   end
 
   def save!
-    if !split.feature_gate? && !existing_assignment
+    if should_create_or_update_assignment?
       ArbitraryAssignmentCreation.create!(
         visitor_id: visitor_id,
         split_name: split_name,
         variant: variant_calculator.variant,
         mixpanel_result: mixpanel_result,
-        context: context
+        context: context,
+        updated_at: updated_at
       )
     end
   end
@@ -39,5 +40,15 @@ class DeterministicAssignmentCreation
 
   def visitor
     @visitor ||= Visitor.from_id(visitor_id)
+  end
+
+  private
+
+  def should_create_or_update_assignment?
+    !split.feature_gate? && (!existing_assignment || existing_assignment.mixpanel_result != @mixpanel_result)
+  end
+
+  def updated_at
+    existing_assignment && existing_assignment.updated_at
   end
 end


### PR DESCRIPTION
### Summary

https://github.com/Betterment/test_track/pull/123 introduced a change that results in the `mixpanel_result` never being updated when the client sends a request to `DeterministicAssignmentCreation` for an existing assignment. I believe the sequence of events would look something like this:

1. The client encounters a split and sends the first request to `Api::V1::AssignmentEventsController` with params that have a `nil` `mixpanel_result`.
2. The client's request to the analytics library succeeds and it sends another request to `Api::V1::AssignmentEventsController` with params that have a `"success"` `mixpanel_result`.
3. The `DeterministicAssignmentCreation` doesn't call `ArbitraryAssignmentCreation` because it finds an `existing_assignment`.
4. On a subsequent page load the client retrieves the split registry and sees a split with `"unsynced": true`.
5. The client sends another request to `Api::V1::AssignmentEventsController` with params that have a `"success"` `mixpanel_result`.
6. The `DeterministicAssignmentCreation` doesn't call `ArbitraryAssignmentCreation` because it finds an `existing_assignment`.

4 to 6 keep repeating for each page load.

This changes proposes a `should_create_or_update_assignment?` expression that incorporates a comparison of whether the existing and new `mixpanel_result`s are equal.

It also adds an optional `created_at` attr to `ArbitraryAssignmentCreation` so we can choose to preserve the existing assignment timestamp if we don't want the default `now`.

/domain @Betterment/test_track_core 
/platform @jmileham @aburgel 
