### PR TITLE
Update assignment when mixpanel result has changed

### DIFF
--- a/app/models/arbitrary_assignment_creation.rb
+++ b/app/models/arbitrary_assignment_creation.rb
@@ -1,5 +1,5 @@
 class ArbitraryAssignmentCreation
-  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context, :force
+  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context, :force, :updated_at
 
   def initialize( # rubocop:disable Metrics/ParameterLists
     visitor_id: nil,
@@ -8,7 +8,8 @@ class ArbitraryAssignmentCreation
     mixpanel_result: nil,
     bulk_assignment_id: nil,
     context: nil,
-    force: false
+    force: false,
+    updated_at: nil
   )
     @visitor_id = visitor_id
     @split_name = split_name
@@ -17,6 +18,7 @@ class ArbitraryAssignmentCreation
     @bulk_assignment_id = bulk_assignment_id
     @context = context
     @force = force
+    @updated_at = updated_at
   end
 
   def save!
@@ -90,7 +92,7 @@ class ArbitraryAssignmentCreation
       mixpanel_result: mixpanel_result,
       bulk_assignment_id: bulk_assignment_id_for_save,
       context: context_for_save,
-      updated_at: now,
+      updated_at: updated_at || now,
       force: force
     }
   end

--- a/app/models/arbitrary_assignment_creation.rb
+++ b/app/models/arbitrary_assignment_creation.rb
@@ -8,8 +8,7 @@ class ArbitraryAssignmentCreation
     mixpanel_result: nil,
     bulk_assignment_id: nil,
     context: nil,
-    force: false,
-    updated_at: nil
+    force: false
   )
     @visitor_id = visitor_id
     @split_name = split_name
@@ -18,7 +17,6 @@ class ArbitraryAssignmentCreation
     @bulk_assignment_id = bulk_assignment_id
     @context = context
     @force = force
-    @updated_at = updated_at
   end
 
   def save!
@@ -92,7 +90,7 @@ class ArbitraryAssignmentCreation
       mixpanel_result: mixpanel_result,
       bulk_assignment_id: bulk_assignment_id_for_save,
       context: context_for_save,
-      updated_at: updated_at || now,
+      updated_at: now,
       force: force
     }
   end

--- a/app/models/arbitrary_assignment_creation.rb
+++ b/app/models/arbitrary_assignment_creation.rb
@@ -1,5 +1,5 @@
 class ArbitraryAssignmentCreation
-  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context, :force, :updated_at
+  attr_reader :visitor_id, :split_name, :variant, :bulk_assignment_id, :context, :force
 
   def initialize( # rubocop:disable Metrics/ParameterLists
     visitor_id: nil,

--- a/app/models/deterministic_assignment_creation.rb
+++ b/app/models/deterministic_assignment_creation.rb
@@ -14,13 +14,14 @@ class DeterministicAssignmentCreation
   end
 
   def save!
-    if !split.feature_gate? && !existing_assignment
+    if should_create_or_update_assignment?
       ArbitraryAssignmentCreation.create!(
         visitor_id: visitor_id,
         split_name: split_name,
         variant: variant_calculator.variant,
         mixpanel_result: mixpanel_result,
-        context: context
+        context: context,
+        updated_at: updated_at
       )
     end
   end
@@ -39,5 +40,15 @@ class DeterministicAssignmentCreation
 
   def visitor
     @visitor ||= Visitor.from_id(visitor_id)
+  end
+
+  private
+
+  def should_create_or_update_assignment?
+    !split.feature_gate? && (!existing_assignment || existing_assignment.mixpanel_result != @mixpanel_result)
+  end
+
+  def updated_at
+    existing_assignment && existing_assignment.updated_at
   end
 end

--- a/app/models/deterministic_assignment_creation.rb
+++ b/app/models/deterministic_assignment_creation.rb
@@ -13,15 +13,19 @@ class DeterministicAssignmentCreation
     new(params).tap(&:save!)
   end
 
-  def save!
-    if should_create_or_update_assignment?
+  def save! # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    return if split.feature_gate?
+
+    if existing_assignment.present?
+      existing_assignment.assign_attributes(mixpanel_result: mixpanel_result)
+      existing_assignment.save!(touch: false)
+    else
       ArbitraryAssignmentCreation.create!(
         visitor_id: visitor_id,
         split_name: split_name,
         variant: variant_calculator.variant,
         mixpanel_result: mixpanel_result,
-        context: context,
-        updated_at: updated_at
+        context: context
       )
     end
   end
@@ -35,20 +39,10 @@ class DeterministicAssignmentCreation
   end
 
   def existing_assignment
-    Assignment.find_by visitor: visitor, split: split
+    @existing_assignment ||= Assignment.find_by visitor: visitor, split: split
   end
 
   def visitor
     @visitor ||= Visitor.from_id(visitor_id)
-  end
-
-  private
-
-  def should_create_or_update_assignment?
-    !split.feature_gate? && (!existing_assignment || existing_assignment.mixpanel_result != @mixpanel_result)
-  end
-
-  def updated_at
-    existing_assignment && existing_assignment.updated_at
   end
 end

--- a/app/models/deterministic_assignment_creation.rb
+++ b/app/models/deterministic_assignment_creation.rb
@@ -17,8 +17,10 @@ class DeterministicAssignmentCreation
     return if split.feature_gate?
 
     if existing_assignment.present?
-      existing_assignment.assign_attributes(mixpanel_result: mixpanel_result)
-      existing_assignment.save!(touch: false)
+      if existing_assignment.unsynced?
+        existing_assignment.assign_attributes(mixpanel_result: mixpanel_result)
+        existing_assignment.save!(touch: false)
+      end
     else
       ArbitraryAssignmentCreation.create!(
         visitor_id: visitor_id,

--- a/spec/controllers/api/v1/assignment_events_controller_spec.rb
+++ b/spec/controllers/api/v1/assignment_events_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Api::V1::AssignmentEventsController, type: :controller do
 
       expect {
         post :create, params: create_params
-      }.to change { PreviousAssignment.count }.by(1)
+      }.not_to change { PreviousAssignment.count }
 
       expect(response).to have_http_status :no_content
       assignment = Assignment.first

--- a/spec/models/arbitrary_assignment_creation_spec.rb
+++ b/spec/models/arbitrary_assignment_creation_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe ArbitraryAssignmentCreation, type: :model do
         expect(existing_assignment.mixpanel_result).to eq "success"
       end
 
-      it "overrides an existing assignment's mixpanel_result with a non-nil mixpanel_result and keeps the original updated_at" do
+      it "overrides an existing assignment's mixpanel_result with a non-nil mixpanel_result" do
         visitor = FactoryBot.create(:visitor, id: params[:visitor_id])
         existing_assignment = FactoryBot.create(
           :assignment,

--- a/spec/models/arbitrary_assignment_creation_spec.rb
+++ b/spec/models/arbitrary_assignment_creation_spec.rb
@@ -3,15 +3,13 @@ require 'rails_helper'
 RSpec.describe ArbitraryAssignmentCreation, type: :model do
   subject { ArbitraryAssignmentCreation.new params }
 
-  let(:updated_at) { nil }
   let(:params) do
     {
       visitor_id: SecureRandom.uuid,
       split_name: "split",
       variant: "variant1",
       mixpanel_result: "success",
-      context: "the_context",
-      updated_at: updated_at
+      context: "the_context"
     }
   end
 
@@ -156,7 +154,6 @@ RSpec.describe ArbitraryAssignmentCreation, type: :model do
     end
 
     context "mixpanel_result" do
-      let(:updated_at) { Date.parse("2016-08-07") }
       let(:assignment_creation_without_mixpanel_result) { ArbitraryAssignmentCreation.new params.except(:mixpanel_result) }
       let(:assignment_creation_with_mixpanel_result) { subject }
 
@@ -197,7 +194,6 @@ RSpec.describe ArbitraryAssignmentCreation, type: :model do
 
         existing_assignment.reload
         expect(existing_assignment.mixpanel_result).to eq "success"
-        expect(existing_assignment.updated_at).to eq Date.parse("2016-08-07")
       end
 
       it "overrides an existing assignment's mixpanel_result when switching variants" do

--- a/spec/models/deterministic_assignment_creation_spec.rb
+++ b/spec/models/deterministic_assignment_creation_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe DeterministicAssignmentCreation, type: :model do
           mixpanel_result: original_mixpanel_result,
           updated_at: updated_at)
 
-          assignment.reload
+        assignment.reload
       end
 
       it "does not create a new assignment or change existing assignment" do

--- a/spec/models/deterministic_assignment_creation_spec.rb
+++ b/spec/models/deterministic_assignment_creation_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe DeterministicAssignmentCreation, type: :model do
           split: split, variant: "variant3",
           visitor: Visitor.from_id("bc8833fd-1bdc-4751-a13c-8aba0ef95a3b"),
           mixpanel_result: original_mixpanel_result,
+          created_at: 1.year.ago,
           updated_at: updated_at)
       end
 

--- a/spec/models/deterministic_assignment_creation_spec.rb
+++ b/spec/models/deterministic_assignment_creation_spec.rb
@@ -63,17 +63,18 @@ RSpec.describe DeterministicAssignmentCreation, type: :model do
         .with(hash_including(context: "the_context"))
     end
 
-    context 'with an existing assignement' do
+    context 'with an existing assignment' do
       let(:updated_at) { Time.zone.parse("2016-08-07 23:45:59") }
       let(:original_mixpanel_result) { "success" }
 
       let!(:existing_assignment) do
-        FactoryBot.create(:assignment,
+        assignment = FactoryBot.create(:assignment,
           split: split, variant: "variant3",
           visitor: Visitor.from_id("bc8833fd-1bdc-4751-a13c-8aba0ef95a3b"),
           mixpanel_result: original_mixpanel_result,
-          created_at: 1.year.ago,
           updated_at: updated_at)
+
+          assignment.reload
       end
 
       it "does not create a new assignment or change existing assignment" do

--- a/spec/models/deterministic_assignment_creation_spec.rb
+++ b/spec/models/deterministic_assignment_creation_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe DeterministicAssignmentCreation, type: :model do
 
   let(:visitor_id) { SecureRandom.uuid }
 
+  let(:mixpanel_result) { "success" }
   let(:params) do
     {
       visitor_id: "bc8833fd-1bdc-4751-a13c-8aba0ef95a3b",
       split_name: "split",
-      mixpanel_result: "success",
+      mixpanel_result: mixpanel_result,
       context: "the_context"
     }
   end
@@ -83,8 +84,9 @@ RSpec.describe DeterministicAssignmentCreation, type: :model do
         expect(existing_assignment.reload.attributes).to eq original_attributes
       end
 
-      context 'when the mixpanel result changes' do
+      context 'when the mixpanel result changes from failure to success' do
         let(:original_mixpanel_result) { "failure" }
+        let(:mixpanel_result) { "success" }
 
         it "updates the new mixpanel_result but leaves existing updated_at" do
           subject.save!
@@ -92,6 +94,33 @@ RSpec.describe DeterministicAssignmentCreation, type: :model do
           expect(ArbitraryAssignmentCreation).not_to have_received(:create!)
           expect(existing_assignment.reload.mixpanel_result).to eq "success"
           expect(existing_assignment.reload.updated_at).to eq Time.zone.parse("2016-08-07 23:45:59")
+        end
+      end
+
+      context 'when the mixpanel result changes from nil to success' do
+        let(:original_mixpanel_result) { nil }
+        let(:mixpanel_result) { "success" }
+
+        it "updates the new mixpanel_result but leaves existing updated_at" do
+          subject.save!
+
+          expect(ArbitraryAssignmentCreation).not_to have_received(:create!)
+          expect(existing_assignment.reload.mixpanel_result).to eq "success"
+          expect(existing_assignment.reload.updated_at).to eq Time.zone.parse("2016-08-07 23:45:59")
+        end
+      end
+
+      context 'when the mixpanel result goes from success to failure' do
+        let(:original_mixpanel_result) { "success" }
+        let(:mixpanel_result) { "failure" }
+
+        it "does not allow assignment to change" do
+          original_attributes = existing_assignment.attributes
+
+          subject.save!
+
+          expect(ArbitraryAssignmentCreation).not_to have_received(:create!)
+          expect(existing_assignment.reload.attributes).to eq original_attributes
         end
       end
     end


### PR DESCRIPTION
NOTE: This is built upon #125. I had to open a new PR since that PR was off of a fork. I made the following modification: Consolidated the logic in `DeterministicAssignmentCreation` to reduce coupling to `ArbitraryAssignmentCreation` and to close the window in which a new variant could  be unintentially assigned.


### Summary

https://github.com/Betterment/test_track/pull/123 introduced a change that results in the `mixpanel_result` never being updated when the client sends a request to `DeterministicAssignmentCreation` for an existing assignment. I believe the sequence of events would look something like this:

1. The client encounters a split and sends the first request to `Api::V1::AssignmentEventsController` with params that have a `nil` `mixpanel_result`.
2. The client's request to the analytics library succeeds and it sends another request to `Api::V1::AssignmentEventsController` with params that have a `"success"` `mixpanel_result`.
3. The `DeterministicAssignmentCreation` doesn't call `ArbitraryAssignmentCreation` because it finds an `existing_assignment`.
4. On a subsequent page load the client retrieves the split registry and sees a split with `"unsynced": true`.
5. The client sends another request to `Api::V1::AssignmentEventsController` with params that have a `"success"` `mixpanel_result`.
6. The `DeterministicAssignmentCreation` doesn't call `ArbitraryAssignmentCreation` because it finds an `existing_assignment`.

4 to 6 keep repeating for each page load.

~~This changes proposes a `should_create_or_update_assignment?` expression that incorporates a comparison of whether the existing and new `mixpanel_result`s are equal.~~

~~It also adds an optional `created_at` attr to `ArbitraryAssignmentCreation` so we can choose to preserve the existing assignment timestamp if we don't want the default `now`.~~

/domain @jmileham 
/platform @jmileham 
/cc @joejansen 