### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: ruby
+
+services:
+  - xvfb
+
+addons:
+  postgresql: '9.6'
+
 rvm:
   - 2.4.2
   - 2.6.2
-addons:
-  postgresql: '9.4'
+
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - gem update --system
   - gem install bundler
+
 before_script:
-  - psql -c 'create database test_track_test;' -U postgres
+  - bundle exec rake db:create


### PR DESCRIPTION
### Summary

Travis builds are braking with this error:

```
$ sh -e /etc/init.d/xvfb start
sh: 0: Can't open /etc/init.d/xvfb
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .
```

It looks like we have an out of date config for xvfb. The [latest guidance](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-services) is to invoke it as a service.

I also cleaned up some of the other config. 

/domain @Betterment/test_track_core 
/no-platform
