### PR TITLE
Run tests against postgres 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,16 @@ addons:
       - postgresql-11
       - postgresql-client-11
 
+env:
+  global:
+    - PGPORT=5433
+
 rvm:
   - 2.4.9
   - 2.6.5
 
 before_install:
-  - gem update --system 3.0.3
+  - gem update --system
   - gem install bundler
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,20 @@ dist: bionic
 language: ruby
 
 services:
+  - postgresql
   - xvfb
 
+
 addons:
-  postgresql: '11'
+  postgresql: 11
+  apt:
+    packages:
+      - postgresql-11
+      - postgresql-client-11
 
 rvm:
-  - 2.4.2
-  - 2.6.2
+  - 2.4.9
+  - 2.6.5
 
 before_install:
   - gem update --system 3.0.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ services:
 addons:
   postgresql: '11'
 
-env:
-  global:
-  - PGPORT=5433
-
 rvm:
   - 2.4.2
   - 2.6.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,14 @@ addons:
     - postgresql-client-11
 env:
   global:
-  - PGPORT=5432
+  - PGPORT=5433
 
 rvm:
   - 2.4.2
   - 2.6.2
 
 before_install:
-  - gem uninstall bundler
-  - gem update --system
+  - gem update --system 3.0.3
   - gem install bundler
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ addons:
     packages:
     - postgresql-11
     - postgresql-client-11
+env:
+  global:
+  - PGPORT=5432
 
 rvm:
   - 2.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 language: ruby
 
 services:
@@ -5,10 +7,7 @@ services:
 
 addons:
   postgresql: '11'
-  apt:
-    packages:
-    - postgresql-11
-    - postgresql-client-11
+
 env:
   global:
   - PGPORT=5433
@@ -20,9 +19,6 @@ rvm:
 before_install:
   - gem update --system 3.0.3
   - gem install bundler
-  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
-  - sudo service postgresql restart
-  - sleep 1
 
 before_script:
   - bundle exec rake db:create

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ rvm:
 before_install:
   - gem update --system 3.0.3
   - gem install bundler
+  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
+  - sudo service postgresql restart
+  - sleep 1
 
 before_script:
   - bundle exec rake db:create

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - xvfb
 
 addons:
-  postgresql: '9.6'
+  postgresql: '11'
 
 rvm:
   - 2.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ rvm:
   - 2.6.2
 
 before_install:
+  - gem uninstall bundler
   - gem update --system
   - gem install bundler
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ services:
 
 addons:
   postgresql: '11'
+  apt:
+    packages:
+    - postgresql-11
+    - postgresql-client-11
 
 rvm:
   - 2.4.2


### PR DESCRIPTION
Update CI to run against postgresql 11

### Summary
CI tests are run currently run against PG 9.6. This update will ensure TestTrack supports the latest major postgres version.

/domain @Betterment/test_track_core 
/platform @Betterment/test_track_core 
