### PR TITLE
More v4 endpoint additions

### DIFF
--- a/app/controllers/api/v4/app_identifier_visitor_configs_controller.rb
+++ b/app/controllers/api/v4/app_identifier_visitor_configs_controller.rb
@@ -1,7 +1,7 @@
 class Api::V4::AppIdentifierVisitorConfigsController < UnauthenticatedApiController
   include CorsSupport
 
-  def show
+  def show # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     build_path = AppVersionBuildPath.new(build_params)
     if build_path.valid?
       app_build = build_path.app_build
@@ -9,6 +9,7 @@ class Api::V4::AppIdentifierVisitorConfigsController < UnauthenticatedApiControl
       visitor = VisitorLookup.new(identifier_params).visitor
       @visitor_id = visitor.id
       @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
+      @experience_sampling_weight = Rails.configuration.experience_sampling_weight
     else
       render_errors build_path
     end

--- a/app/controllers/api/v4/app_visitor_configs_controller.rb
+++ b/app/controllers/api/v4/app_visitor_configs_controller.rb
@@ -1,7 +1,7 @@
 class Api::V4::AppVisitorConfigsController < UnauthenticatedApiController
   include CorsSupport
 
-  def show
+  def show # rubocop:disable Metrics/MethodLength
     build_path = AppVersionBuildPath.new(build_params)
     if build_path.valid?
       app_build = build_path.app_build
@@ -9,6 +9,7 @@ class Api::V4::AppVisitorConfigsController < UnauthenticatedApiController
       @visitor_id = visitor_id
       visitor = Visitor.find_or_initialize_by(id: @visitor_id)
       @assignments = visitor.assignments_for(app_build).includes(:split).order(:updated_at)
+      @experience_sampling_weight = Rails.configuration.experience_sampling_weight
     else
       render_errors build_path
     end

--- a/app/controllers/api/v4/split_registries_controller.rb
+++ b/app/controllers/api/v4/split_registries_controller.rb
@@ -1,0 +1,19 @@
+class Api::V4::SplitRegistriesController < UnauthenticatedApiController
+  include CorsSupport
+
+  def show
+    split_registry = SplitRegistry.new(as_of: split_registry_params[:build_timestamp])
+
+    if split_registry.valid?
+      @split_registry = split_registry
+    else
+      render_errors split_registry
+    end
+  end
+
+  private
+
+  def split_registry_params
+    params.permit(:build_timestamp)
+  end
+end

--- a/app/models/split_registry.rb
+++ b/app/models/split_registry.rb
@@ -20,18 +20,10 @@ class SplitRegistry
   end
 
   def experience_sampling_weight
-    @experience_sampling_weight ||= _experience_sampling_weight
+    Rails.configuration.experience_sampling_weight
   end
 
   private
 
   attr_reader :as_of
-
-  def _experience_sampling_weight
-    Integer(ENV.fetch('EXPERIENCE_SAMPLING_WEIGHT', '1')).tap do |weight|
-      raise <<~TEXT if weight.negative?
-        EXPERIENCE_SAMPLING_WEIGHT, if specified, must be greater than or equal to 0. Use 0 to disable experience events.
-      TEXT
-    end
-  end
 end

--- a/app/views/api/v4/app_identifier_visitor_configs/show.json.jbuilder
+++ b/app/views/api/v4/app_identifier_visitor_configs/show.json.jbuilder
@@ -1,4 +1,5 @@
 json.partial! 'api/v4/app_visitor_configs/show',
   active_splits: @active_splits,
   visitor_id: @visitor_id,
-  assignments: @assignments
+  assignments: @assignments,
+  experience_sampling_weight: @experience_sampling_weight

--- a/app/views/api/v4/app_visitor_configs/_show.json.jbuilder
+++ b/app/views/api/v4/app_visitor_configs/_show.json.jbuilder
@@ -13,3 +13,5 @@ json.visitor do
   json.id visitor_id
   json.assignments assignments, :split_name, :variant
 end
+
+json.experience_sampling_weight experience_sampling_weight

--- a/app/views/api/v4/app_visitor_configs/show.json.jbuilder
+++ b/app/views/api/v4/app_visitor_configs/show.json.jbuilder
@@ -1,4 +1,5 @@
 json.partial! 'api/v4/app_visitor_configs/show',
   active_splits: @active_splits,
   visitor_id: @visitor_id,
-  assignments: @assignments
+  assignments: @assignments,
+  experience_sampling_weight: @experience_sampling_weight

--- a/app/views/api/v4/split_registries/show.json.jbuilder
+++ b/app/views/api/v4/split_registries/show.json.jbuilder
@@ -1,0 +1,12 @@
+json.splits @split_registry.splits do |split|
+  json.name split.name
+
+  json.variants split.registry do |(variant_name, weight)|
+    json.name variant_name
+    json.weight weight
+  end
+
+  json.feature_gate split.feature_gate?
+end
+
+json.(@split_registry, :experience_sampling_weight)

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,11 @@ module TestTrack
       config.rails_semantic_logger.add_file_appender = false
       config.semantic_logger.add_appender(io: $stdout, formatter: :json)
     end
+
+    config.experience_sampling_weight = Integer(ENV.fetch('EXPERIENCE_SAMPLING_WEIGHT', '1')).tap do |weight|
+      raise <<~TEXT if weight.negative?
+        EXPERIENCE_SAMPLING_WEIGHT, if specified, must be greater than or equal to 0. Use 0 to disable experience events.
+      TEXT
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,9 @@ Rails.application.routes.draw do
     end
 
     namespace :v4 do
+      resources :builds, only: [], param: :timestamp do
+        resource :split_registry, only: :show
+      end
       resources :apps, only: [], param: :name do
         resources :versions, only: [], param: :number, constraints: { number: /[\d\.]+/ } do
           resources :builds, only: [], param: :timestamp do

--- a/spec/controllers/api/v2/split_registries_controller_spec.rb
+++ b/spec/controllers/api/v2/split_registries_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V2::SplitRegistriesController, type: :controller do
 
   describe "#show" do
     before do
-      allow(ENV).to receive(:fetch).with('EXPERIENCE_SAMPLING_WEIGHT', any_args).and_return(10)
+      allow(Rails.configuration).to receive(:experience_sampling_weight).and_return(10)
     end
 
     it "includes sampling weight" do

--- a/spec/controllers/api/v3/split_registries_controller_spec.rb
+++ b/spec/controllers/api/v3/split_registries_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Api::V3::SplitRegistriesController, type: :controller do
   describe "#show" do
     before do
-      allow(ENV).to receive(:fetch).with('EXPERIENCE_SAMPLING_WEIGHT', any_args).and_return(10)
+      allow(Rails.configuration).to receive(:experience_sampling_weight).and_return(10)
     end
 
     it "includes sampling weight" do

--- a/spec/controllers/api/v4/app_visitor_configs_controller_spec.rb
+++ b/spec/controllers/api/v4/app_visitor_configs_controller_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Api::V4::AppVisitorConfigsController do
   describe "#show" do
+    before do
+      allow(Rails.configuration).to receive(:experience_sampling_weight).and_return(10)
+    end
+
     let(:app) { FactoryBot.create(:app) }
     let(:feature_gate) { FactoryBot.create(:feature_gate, name: "blab_enabled", registry: { false: 50, true: 50 }) }
     let(:visitor) { FactoryBot.create(:visitor) }
@@ -60,6 +64,18 @@ RSpec.describe Api::V4::AppVisitorConfigsController do
 
       expect(response_json['visitor']['assignments'].first['split_name']).to eq('blab_enabled')
       expect(response_json['visitor']['assignments'].first['variant']).to eq('true')
+    end
+
+    it "includes sampling weight" do
+      get :show, params: {
+        app_name: app.name,
+        version_number: "1.0",
+        build_timestamp: "2019-04-16T14:35:30Z",
+        visitor_id: visitor.id
+      }
+
+      expect(response).to have_http_status :ok
+      expect(response_json['experience_sampling_weight']).to eq(10)
     end
 
     it "returns unprocessable_entity if the app_build url params are invalid" do

--- a/spec/controllers/api/v4/split_registries_controller_spec.rb
+++ b/spec/controllers/api/v4/split_registries_controller_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe Api::V4::SplitRegistriesController, type: :controller do
+  describe "#show" do
+    before do
+      allow(Rails.configuration).to receive(:experience_sampling_weight).and_return(10)
+    end
+
+    it "includes sampling weight" do
+      get :show, params: { build_timestamp: '2019-11-11T14:35:30Z' }
+
+      expect(response).to have_http_status :ok
+      expect(response_json['experience_sampling_weight']).to eq(10)
+    end
+
+    context "without active split on given timestamp" do
+      let!(:split_1) { FactoryBot.create :split, name: "one", finished_at: Time.zone.parse('2019-11-13'), registry: { all: 100 } }
+
+      it "returns empty with no active splits on the timestamp" do
+        expect(split_1).to be_finished
+
+        get :show, params: { build_timestamp: '2019-11-14T14:35:30Z' }
+
+        expect(response).to have_http_status :ok
+        expect(response_json['splits']).to eq([])
+      end
+    end
+
+    context "with splits active on given during timestamp" do
+      let(:split_1) { FactoryBot.create :split, name: "one", finished_at: Time.zone.parse('2019-11-13'), registry: { all: 100 } }
+      let(:split_2) { FactoryBot.create :split, name: "two", registry: { on: 50, off: 50 } }
+      let(:split_3) { FactoryBot.create :split, name: "three_enabled", registry: { true: 99, false: 1 }, feature_gate: true }
+
+      it "returns the full split registry of splits that are active during timestamp" do
+        expect(split_1).to be_finished
+        expect(split_2).not_to be_finished
+        expect(split_3).not_to be_finished
+
+        get :show, params: { build_timestamp: '2019-11-12T14:35:30Z' }
+
+        expect(response).to have_http_status :ok
+        expect(response_json['splits']).to eq([
+          {
+            "name" => "one",
+            "variants" => [
+              {
+                "name" => "all",
+                "weight" => 100
+              }
+            ],
+            "feature_gate" => false
+          },
+          {
+            "name" => "two",
+            "variants" => [
+              {
+                "name" => "on",
+                "weight" => 50
+              },
+              {
+                "name" => "off",
+                "weight" => 50
+              }
+            ],
+            "feature_gate" => false
+          },
+          {
+            "name" => "three_enabled",
+            "variants" => [
+              {
+                "name" => "true",
+                "weight" => 99
+              },
+              {
+                "name" => "false",
+                "weight" => 1
+              }
+            ],
+            "feature_gate" => true
+          }
+        ])
+      end
+    end
+
+    it "returns unprocessable_entity if the timestamp url param is invalid" do
+      get :show, params: { build_timestamp: "2019-04-16 10:38:08 -0400" }
+
+      expect(response).to have_http_status :unprocessable_entity
+    end
+
+    it "returns unprocessable_entity if the timestamp url param is missing" do
+      get :show, params: { build_timestamp: "" }
+
+      expect(response).to have_http_status :unprocessable_entity
+    end
+  end
+end

--- a/spec/models/split_registry_spec.rb
+++ b/spec/models/split_registry_spec.rb
@@ -49,39 +49,4 @@ RSpec.describe SplitRegistry do
       expect(described_class.new(as_of: 1.day.ago).splits.all).to include(split)
     end
   end
-
-  describe "#experience_sampling_weight" do
-    it "memoizes the env var fetch" do
-      allow(ENV).to receive(:fetch).and_call_original
-
-      subject.experience_sampling_weight
-      subject.experience_sampling_weight
-
-      expect(ENV).to have_received(:fetch).with('EXPERIENCE_SAMPLING_WEIGHT', any_args).exactly(:once)
-    end
-
-    it "returns 1 with no env var" do
-      with_env EXPERIENCE_SAMPLING_WEIGHT: nil do
-        expect(subject.experience_sampling_weight).to eq 1
-      end
-    end
-
-    it "returns an positive value specified" do
-      with_env EXPERIENCE_SAMPLING_WEIGHT: '10' do
-        expect(subject.experience_sampling_weight).to eq 10
-      end
-    end
-
-    it "returns zero when specified" do
-      with_env EXPERIENCE_SAMPLING_WEIGHT: '0' do
-        expect(subject.experience_sampling_weight).to eq 0
-      end
-    end
-
-    it "blows up on negative" do
-      with_env EXPERIENCE_SAMPLING_WEIGHT: '-1' do
-        expect { subject.experience_sampling_weight }.to raise_error(/greater than or equal/)
-      end
-    end
-  end
 end

--- a/spec/models/split_registry_spec.rb
+++ b/spec/models/split_registry_spec.rb
@@ -49,4 +49,10 @@ RSpec.describe SplitRegistry do
       expect(described_class.new(as_of: 1.day.ago).splits.all).to include(split)
     end
   end
+
+  describe '#experience_sampling_weight' do
+    it "returns the default value as an integer" do
+      expect(Rails.configuration.experience_sampling_weight).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

in #148 we discussed creating a v4 version of the /builds/:timestamp/split_registry endpoint that is used by the rails client and js client (transitively).

this PR adds that endpoint for future consumption. this is nice in that it allows all the clients to be consuming the same version of the split registry schema (v4) whenever they're updated.

this PR also introduces the `experience_sampling_weight` to the v4 endpoints.

**NOTE: i moved the `experience_sampling_weight` loading behavior from the `SplitRegistry` model to the `Rails.configuration` in `application.rb`. This felt like a better way to share the behavior between the `SplitRegistry`-based and the non-`SplitRegistry`-based  ways of getting at the list of applicable splits for a client (via app+version+timestamp or via build timestamp) cc @jmileham @aburgel the main result of this move is that the tests covering the tiny bit of behavior for validating the experience sampling weight are gone**

/domain @Betterment/test_track_core 
/no-platform
