### PR TITLE
Add Github search link if GITHUB_ORGANIZATION ENV variable is set

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,14 @@ module ApplicationHelper
   def percentage(ratio)
     "#{(ratio * 100).round}%"
   end
+
+  def github_search_enabled?
+    ENV['GITHUB_ORGANIZATION'].present?
+  end
+
+  def github_search_url(split)
+    return nil unless github_search_enabled?
+
+    "https://github.com/search?q=org%3A#{ENV['GITHUB_ORGANIZATION']}+#{split.name}&type=code"
+  end
 end

--- a/app/views/admin/splits/_details.html.erb
+++ b/app/views/admin/splits/_details.html.erb
@@ -39,11 +39,18 @@
       </tr>
       <tr>
         <td>Creation</td>
-        <td>
+        <td colspan="2">
           <span><%= @split.created_at %></span>
         </td>
-        <td>&nbsp;</td>
       </tr>
+      <% if github_search_enabled? %>
+        <tr>
+          <td>Github</td>
+          <td colspan="2">
+            <span><%= link_to "Search for uses", github_search_url(@split), target: '_blank' %></span>
+          </td>
+        </tr>
+      <% end %>
     </table>
     <% if @split.feature_gate? %>
       <p>

--- a/app/views/admin/splits/_split.html.erb
+++ b/app/views/admin/splits/_split.html.erb
@@ -11,5 +11,9 @@
   <td>
     <%= link_to "View", admin_split_path(split) %>
   </td>
+  <% if github_search_enabled? %>
+    <td>
+      <%= link_to "Github", github_search_url(split), target: "_blank" %>
+    </td>
+  <% end %>
 </tr>
-

--- a/app/views/admin/splits/_table_header.html.erb
+++ b/app/views/admin/splits/_table_header.html.erb
@@ -1,8 +1,0 @@
-<thead>
-  <tr>
-    <th>Name</th>
-    <th>Weightings</th>
-    <th>Owner App</th>
-    <th>View</th>
-  </tr>
-</thead>

--- a/app/views/admin/splits/index.html.erb
+++ b/app/views/admin/splits/index.html.erb
@@ -10,6 +10,9 @@
         <th>Owner App</th>
         <th>Date Migrated</th>
         <th></th>
+        <% if github_search_enabled? %>
+          <th></th>
+        <% end %>
       </tr>
     </thead>
     <tbody>

--- a/spec/system/admin_login_spec.rb
+++ b/spec/system/admin_login_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe 'admin login' do
     subject.log_out.click
     expect(app.admin_session_new_page).to be_loaded
   end
+
+  context 'if GITHUB_ORGANIZATION ENV is set' do
+    let!(:split) { FactoryBot.create(:split, name: 'test_split') }
+
+    before do
+      ENV['GITHUB_ORGANIZATION'] = 'test'
+    end
+
+    it 'displays Github search link' do
+      login
+
+      expect(subject).to have_text("Github")
+    end
+  end
 end

--- a/spec/system/admin_split_details_create_spec.rb
+++ b/spec/system/admin_split_details_create_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe 'admin can add details to a split' do
     login
   end
 
+  context 'if GITHUB_ORGANIZATION ENV is set' do
+    before do
+      ENV['GITHUB_ORGANIZATION'] = 'test'
+    end
+
+    it 'displays Github search link' do
+      split_page.load split_id: split.id
+
+      expect(split_page).to be_loaded
+      expect(split_page).to have_text("Github")
+      expect(split_page).to have_text("Search for uses")
+    end
+  end
+
   it 'allows admins to add details to a split' do
     split_page.load split_id: split.id
     expect(split_page).to be_loaded


### PR DESCRIPTION
### Summary

When removing splits, it's important to verify if they're no longer in use across the code base. Right now, that process is manual and tedious and challenging for others to replicate. This PR brings a link to the UI (split table and split detail) that provides a quick reference to Github to validate that splits are no longer active.

<img width="1290" alt="Screen Shot 2023-02-20 at 3 33 47 PM" src="https://user-images.githubusercontent.com/606/220213057-97216184-655f-4fc7-89f9-9cf7264037f0.png">
