### PR TITLE
Remove the newrelic RPM gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'rack-timeout'
 gem 'airbrake', '~> 7.3.5', require: false
 gem 'sentry-raven', require: false
 
-gem 'newrelic_rpm'
 gem 'ddtrace', require: false
 
 gem 'rails_semantic_logger', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,7 +246,6 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    newrelic_rpm (9.0.0)
     nio4r (2.5.8)
     nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
@@ -519,7 +518,6 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  newrelic_rpm
   nokogiri
   omniauth-rails_csrf_protection
   omniauth-saml


### PR DESCRIPTION
### Summary

This gem was out-of-date for a long time, and got inadvertently upgraded in #182. The newer version attempts to connect without valid credentials, so we're removing it for now (to avoid solving for the ability to optionally inject valid credentials).

/domain @Betterment/test_track_core 
/no-platform
