### PR TITLE
Support updating owner via migration

### DIFF
--- a/app/controllers/api/v2/migrations/splits_controller.rb
+++ b/app/controllers/api/v2/migrations/splits_controller.rb
@@ -11,7 +11,10 @@ class Api::V2::Migrations::SplitsController < AuthenticatedApiController
   private
 
   def create_params
-    # rails-sponsored approach https://github.com/rails/rails/pull/12609
-    params.permit(:name, weighting_registry: params[:weighting_registry].try(:keys)) # ensure weighting_registry is a hash of scalars
+    params.permit(
+      :name,
+      :owner,
+      weighting_registry: params[:weighting_registry].try(:keys),  # ensure weighting_registry is a hash of scalars
+    )
   end
 end

--- a/app/models/split_upsert.rb
+++ b/app/models/split_upsert.rb
@@ -1,13 +1,13 @@
 class SplitUpsert
   include ActiveModel::Model
 
-  attr_accessor :app, :name, :decided_at, :finished_at, :require_app_name_prefix
+  attr_accessor :app, :name, :owner, :decided_at, :finished_at, :require_app_name_prefix
   attr_reader :weighting_registry
 
   validate :split_must_be_valid
 
   def save # rubocop:disable Metrics/AbcSize
-    split.assign_attributes(finished_at: finished_at, decided_at: decided_at, require_app_name_prefix: require_app_name_prefix)
+    split.assign_attributes(finished_at: finished_at, decided_at: decided_at, require_app_name_prefix: require_app_name_prefix, owner: owner)
     split.reassign_weight(merged_registry) unless split.registry == merged_registry
     return false unless valid?
 

--- a/app/models/split_upsert.rb
+++ b/app/models/split_upsert.rb
@@ -7,7 +7,8 @@ class SplitUpsert
   validate :split_must_be_valid
 
   def save # rubocop:disable Metrics/AbcSize
-    split.assign_attributes(finished_at: finished_at, decided_at: decided_at, require_app_name_prefix: require_app_name_prefix, owner: owner)
+    split.assign_attributes(finished_at: finished_at, decided_at: decided_at, require_app_name_prefix: require_app_name_prefix)
+    split.assign_attributes(owner: owner) unless owner.nil?
     split.reassign_weight(merged_registry) unless split.registry == merged_registry
     return false unless valid?
 

--- a/spec/controllers/api/v2/migrations/splits_controller_spec.rb
+++ b/spec/controllers/api/v2/migrations/splits_controller_spec.rb
@@ -19,12 +19,13 @@ RSpec.describe Api::V2::Migrations::SplitsController do
 
     describe '#create' do
       it "creates a new split with desired weightings" do
-        post :create, params: { name: 'default_app.foobar', weighting_registry: { foo: 10, bar: 90 } }
+        post :create, params: { name: 'default_app.foobar', owner: 'b4c', weighting_registry: { foo: 10, bar: 90 } }
 
         expect(response).to have_http_status(:no_content)
         split = Split.find_by(name: 'default_app.foobar', owner_app: default_app)
         expect(split).to be_truthy
         expect(split.registry).to eq 'foo' => 10, 'bar' => 90
+        expect(split.owner).to eq 'b4c'
       end
 
       it 'returns errors when invalid' do

--- a/spec/controllers/api/v2/migrations/splits_controller_spec.rb
+++ b/spec/controllers/api/v2/migrations/splits_controller_spec.rb
@@ -19,13 +19,23 @@ RSpec.describe Api::V2::Migrations::SplitsController do
 
     describe '#create' do
       it "creates a new split with desired weightings" do
-        post :create, params: { name: 'default_app.foobar', owner: 'b4c', weighting_registry: { foo: 10, bar: 90 } }
+        post :create, params: { name: 'default_app.foobar', owner: 'test-owner', weighting_registry: { foo: 10, bar: 90 } }
 
         expect(response).to have_http_status(:no_content)
         split = Split.find_by(name: 'default_app.foobar', owner_app: default_app)
         expect(split).to be_truthy
         expect(split.registry).to eq 'foo' => 10, 'bar' => 90
-        expect(split.owner).to eq 'b4c'
+        expect(split.owner).to eq 'test-owner'
+      end
+
+      it "does not remove ownership from an existing split if the variable is missing" do
+        split = Split.create(name: 'default_app.foobar', owner: 'test-owner', owner_app: default_app)
+        expect(split.owner).to eq 'test-owner'
+
+        expect {
+          post :create, params: { name: 'default_app.foobar', weighting_registry: { foo: 10, bar: 90 } }
+          expect(response).to have_http_status(:no_content)
+        }.to not_change{ split.owner }.from('test-owner')
       end
 
       it 'returns errors when invalid' do

--- a/spec/controllers/api/v2/migrations/splits_controller_spec.rb
+++ b/spec/controllers/api/v2/migrations/splits_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Api::V2::Migrations::SplitsController do
         expect {
           post :create, params: { name: 'default_app.foobar', weighting_registry: { foo: 10, bar: 90 } }
           expect(response).to have_http_status(:no_content)
-        }.to not_change{ split.owner }.from('test-owner')
+        }.to not_change { split.owner }.from('test-owner')
       end
 
       it 'returns errors when invalid' do


### PR DESCRIPTION
### Summary

Supports updating ownership of a split from testtrack-cli 1.5.0.
