### PR TITLE
pass id to quote to fix deprecation

### DIFF
--- a/app/models/bulk_reassignment.rb
+++ b/app/models/bulk_reassignment.rb
@@ -63,7 +63,7 @@ class BulkReassignment
         variant = #{connection.quote(bulk_assignment.variant)},
         updated_at = #{connection.quote(now)},
         mixpanel_result = NULL,
-        bulk_assignment_id = #{connection.quote(bulk_assignment)},
+        bulk_assignment_id = #{connection.quote(bulk_assignment.id)},
         visitor_supersession_id = NULL,
         context = 'bulk_assignment',
         force = #{connection.quote(bulk_assignment.force)}


### PR DESCRIPTION
### Summary
Noticed the following deprecation warning while running specs:

```
DEPRECATION WARNING: Passing an Active Record object to `quote` directly is deprecated
and will be no longer quoted as id value in Rails 7.0.
 (called from update_assignments at /Users/ricardogarza/src/test_track/app/models/bulk_reassignment.rb:66)
```

This PR simply passes an id to `quote` directly, to avoid the warning.
