### PR TITLE
Upgrade to Rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.1.0'
+gem 'rails', '~> 7.0.0'
 gem 'net-smtp', require: false # required on Rails 6 for Ruby 3.1+ support
 gem 'net-pop', require: false # required on Rails 6 for Ruby 3.1+ support
 gem 'net-imap', require: false # required on Rails 6 for Ruby 3.1+ support
@@ -52,12 +52,16 @@ gem 'foreman'
 gem 'delayed_job'
 gem 'delayed_job_active_record'
 
-gem 'with_transactional_lock'
+source "https://rubygems.pkg.github.com/betterment" do
+  gem "with_transactional_lock"
+end
 
 gem 'bootsnap', '>= 1.3.0', require: false
 
 # Avoid deprecation notices by pinning mail to Ruby 2.7.5 compatible version
 gem 'mail', '~> 2.7.1'
+
+gem 'sprockets-rails'
 
 group :development, :test do
   gem 'simplecov', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'foreman'
 gem 'delayed_job'
 gem 'delayed_job_active_record'
 
-gem "with_transactional_lock"
+gem 'with_transactional_lock'
 
 gem 'bootsnap', '>= 1.3.0', require: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -52,9 +52,7 @@ gem 'foreman'
 gem 'delayed_job'
 gem 'delayed_job_active_record'
 
-source "https://rubygems.pkg.github.com/betterment" do
-  gem "with_transactional_lock"
-end
+gem "with_transactional_lock"
 
 gem 'bootsnap', '>= 1.3.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -482,18 +482,14 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    with_transactional_lock (2.0.1)
+      rails (>= 6.0, < 7.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yarjuf (2.0.0)
       builder
       rspec (~> 3)
     zeitwerk (2.6.7)
-
-GEM
-  remote: https://rubygems.pkg.github.com/betterment/
-  specs:
-    with_transactional_lock (2.0.1)
-      rails (>= 6.0, < 7.1)
 
 PLATFORMS
   arm64-darwin
@@ -558,7 +554,7 @@ DEPENDENCIES
   travis (~> 1.8.0)
   turbolinks
   web-console (>= 3.3.0)
-  with_transactional_lock!
+  with_transactional_lock
 
 BUNDLED WITH
    2.4.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,65 +15,71 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (6.1.7.3)
-      actionpack (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
+    actioncable (7.0.5)
+      actionpack (= 7.0.5)
+      activesupport (= 7.0.5)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (6.1.7.3)
-      actionpack (= 6.1.7.3)
-      activejob (= 6.1.7.3)
-      activerecord (= 6.1.7.3)
-      activestorage (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
+    actionmailbox (7.0.5)
+      actionpack (= 7.0.5)
+      activejob (= 7.0.5)
+      activerecord (= 7.0.5)
+      activestorage (= 7.0.5)
+      activesupport (= 7.0.5)
       mail (>= 2.7.1)
-    actionmailer (6.1.7.3)
-      actionpack (= 6.1.7.3)
-      actionview (= 6.1.7.3)
-      activejob (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.5)
+      actionpack (= 7.0.5)
+      actionview (= 7.0.5)
+      activejob (= 7.0.5)
+      activesupport (= 7.0.5)
       mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
       rails-dom-testing (~> 2.0)
-    actionpack (6.1.7.3)
-      actionview (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
-      rack (~> 2.0, >= 2.0.9)
+    actionpack (7.0.5)
+      actionview (= 7.0.5)
+      activesupport (= 7.0.5)
+      rack (~> 2.0, >= 2.2.4)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (6.1.7.3)
-      actionpack (= 6.1.7.3)
-      activerecord (= 6.1.7.3)
-      activestorage (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
+    actiontext (7.0.5)
+      actionpack (= 7.0.5)
+      activerecord (= 7.0.5)
+      activestorage (= 7.0.5)
+      activesupport (= 7.0.5)
+      globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (6.1.7.3)
-      activesupport (= 6.1.7.3)
+    actionview (7.0.5)
+      activesupport (= 7.0.5)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (6.1.7.3)
-      activesupport (= 6.1.7.3)
+    activejob (7.0.5)
+      activesupport (= 7.0.5)
       globalid (>= 0.3.6)
-    activemodel (6.1.7.3)
-      activesupport (= 6.1.7.3)
-    activerecord (6.1.7.3)
-      activemodel (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
-    activestorage (6.1.7.3)
-      actionpack (= 6.1.7.3)
-      activejob (= 6.1.7.3)
-      activerecord (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
+    activemodel (7.0.5)
+      activesupport (= 7.0.5)
+    activerecord (7.0.5)
+      activemodel (= 7.0.5)
+      activesupport (= 7.0.5)
+    activestorage (7.0.5)
+      actionpack (= 7.0.5)
+      activejob (= 7.0.5)
+      activerecord (= 7.0.5)
+      activesupport (= 7.0.5)
       marcel (~> 1.0)
       mini_mime (>= 1.1.0)
-    activesupport (6.1.7.3)
+    activesupport (7.0.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     airbrake (7.3.5)
@@ -303,21 +309,20 @@ GEM
     rack-test (2.0.2)
       rack (>= 1.3)
     rack-timeout (0.6.3)
-    rails (6.1.7.3)
-      actioncable (= 6.1.7.3)
-      actionmailbox (= 6.1.7.3)
-      actionmailer (= 6.1.7.3)
-      actionpack (= 6.1.7.3)
-      actiontext (= 6.1.7.3)
-      actionview (= 6.1.7.3)
-      activejob (= 6.1.7.3)
-      activemodel (= 6.1.7.3)
-      activerecord (= 6.1.7.3)
-      activestorage (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
+    rails (7.0.5)
+      actioncable (= 7.0.5)
+      actionmailbox (= 7.0.5)
+      actionmailer (= 7.0.5)
+      actionpack (= 7.0.5)
+      actiontext (= 7.0.5)
+      actionview (= 7.0.5)
+      activejob (= 7.0.5)
+      activemodel (= 7.0.5)
+      activerecord (= 7.0.5)
+      activestorage (= 7.0.5)
+      activesupport (= 7.0.5)
       bundler (>= 1.15.0)
-      railties (= 6.1.7.3)
-      sprockets-rails (>= 2.0.0)
+      railties (= 7.0.5)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -327,12 +332,13 @@ GEM
       rack
       railties (>= 5.1)
       semantic_logger (~> 4.9)
-    railties (6.1.7.3)
-      actionpack (= 6.1.7.3)
-      activesupport (= 6.1.7.3)
+    railties (7.0.5)
+      actionpack (= 7.0.5)
+      activesupport (= 7.0.5)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
     rb-fsevent (0.11.2)
@@ -476,14 +482,18 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    with_transactional_lock (2.0.0)
-      rails (>= 5.1, < 7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yarjuf (2.0.0)
       builder
       rspec (~> 3)
     zeitwerk (2.6.7)
+
+GEM
+  remote: https://rubygems.pkg.github.com/betterment/
+  specs:
+    with_transactional_lock (2.0.1)
+      rails (>= 6.0, < 7.1)
 
 PLATFORMS
   arm64-darwin
@@ -531,7 +541,7 @@ DEPENDENCIES
   psych (< 4)
   puma (~> 5.6)
   rack-timeout
-  rails (~> 6.1.0)
+  rails (~> 7.0.0)
   rails_semantic_logger
   responders
   rspec-rails
@@ -542,12 +552,13 @@ DEPENDENCIES
   simple_form
   simplecov
   site_prism
+  sprockets-rails
   terser
   timecop
   travis (~> 1.8.0)
   turbolinks
   web-console (>= 3.3.0)
-  with_transactional_lock
+  with_transactional_lock!
 
 BUNDLED WITH
    2.4.7

--- a/app/views/api/v1/visitor_details/_assignment_detail.json.jbuilder
+++ b/app/views/api/v1/visitor_details/_assignment_detail.json.jbuilder
@@ -2,4 +2,4 @@ json.split_location assignment.split.location
 json.split_name assignment.split.name
 json.variant_name assignment.variant_detail.display_name
 json.variant_description assignment.variant_detail.description
-json.assigned_at assignment.updated_at.to_s(:iso8601)
+json.assigned_at assignment.updated_at.to_fs(:iso8601)

--- a/config/initializers/types.rb
+++ b/config/initializers/types.rb
@@ -1,1 +1,3 @@
-ActiveRecord::Type.register(:app_version, AppVersionType)
+Rails.application.config.to_prepare do
+  ActiveRecord::Type.register(:app_version, AppVersionType)
+end


### PR DESCRIPTION
### Summary
This updates `test_track` to Rails 7 and fixes a breaking deprecation and a lint.

### Other Information
I'll comment on interesting stuff inline

/domain
