### PR TITLE
Migrate capybara driver to cuprite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,6 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v2
-      - uses: nanasess/setup-chromedriver@v2.2.0
-        with:
-          chromedriver-version: '117.0.5938.92'
-      - run: |
-          export DISPLAY=:99
-          chromedriver --url-base=/wd/hub &
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -52,6 +45,6 @@ jobs:
       - name: Run tests
         run: bundle exec rake
         env:
-          CAPYBARA_DRIVER: selenium_chrome_headless
+          CAPYBARA_DRIVER: better_cuprite
           COMPILE_ASSETS: 0
           EAGER_LOAD: 1

--- a/Gemfile
+++ b/Gemfile
@@ -73,8 +73,6 @@ group :development, :test do
   gem 'dotenv-rails'
 
   gem 'site_prism'
-  gem 'selenium-webdriver'
-
   gem 'factory_bot_rails'
 
   gem 'ruby_spec_helpers', path: 'vendor/gems/ruby_spec_helpers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     ruby_spec_helpers (0.0.1)
       capybara
+      cuprite
       rspec-collection_matchers
       rspec-rails
       rspec-retry (~> 0.4.5)
@@ -134,6 +135,9 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.2)
       railties (>= 6.0.0)
+    cuprite (0.15)
+      capybara (~> 3.0)
+      ferrum (~> 0.14.0)
     date (3.3.3)
     db-query-matchers (0.11.0)
       activesupport (>= 4.0, < 7.1)
@@ -174,6 +178,11 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
+    ferrum (0.14)
+      addressable (~> 2.5)
+      concurrent-ruby (~> 1.1)
+      webrick (~> 1.7)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.15.5)
     foreman (0.87.2)
     gh (0.14.0)
@@ -225,7 +234,7 @@ GEM
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.21.3)
+    loofah (2.21.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.7.1)
@@ -237,10 +246,10 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.2)
+    mini_portile2 (2.8.5)
     mini_racer (0.6.3)
       libv8-node (~> 16.10.0.0)
-    minitest (5.18.1)
+    minitest (5.20.0)
     msgpack (1.6.1)
     multi_json (1.15.0)
     multipart-post (2.3.0)
@@ -257,16 +266,16 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.2)
+    nokogiri (1.15.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.15.2-arm64-darwin)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.2-x86_64-darwin)
+    nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.2-x86_64-linux)
+    nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
-    octicons (17.12.0)
+    octicons (19.8.0)
     omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
@@ -282,10 +291,10 @@ GEM
     parser (3.2.1.0)
       ast (~> 2.4.1)
     pg (1.4.5)
-    primer_view_components (0.1.0)
+    primer_view_components (0.1.9)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-      octicons (>= 17.0.0)
+      octicons (>= 18.0.0)
       view_component (> 2.0, < 4.0)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -302,7 +311,7 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (2.2.7)
     rack-protection (3.0.5)
       rack
@@ -323,8 +332,9 @@ GEM
       activesupport (= 7.0.6)
       bundler (>= 1.15.0)
       railties (= 7.0.6)
-    rails-dom-testing (2.0.3)
-      activesupport (>= 4.2.0)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
@@ -464,7 +474,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    view_component (2.82.0)
+    view_component (3.7.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -479,6 +489,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.8.1)
     websocket (1.2.10)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -543,7 +554,6 @@ DEPENDENCIES
   responders
   rspec-rails
   ruby_spec_helpers!
-  selenium-webdriver
   sentry-raven
   shoulda-matchers
   simple_form

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ export WHITELIST_CORS_HOSTS=yoursite.example.org,othersite.example.org
 #### Configuration for Chrome extension
 In order to use the TestTrack Chrome extension, you will need to set up the `BROWSER_EXTENSION_SHARED_SECRET` environment variable. [Details.](https://github.com/Betterment/test_track_chrome_extension#building-the-extension)
 
+#### Running specs
+
+To run all specs:
+```bash
+bundle exec rspec
+```
+
+If you are interested in hitting a `binding.pry` somewhere while playing around with your development environment, you can use `binding.pry_remote` in your code.  When reloading the page you expect to have the breakpoint, the browser should freeze and you should be able to connect to your console via running in your terminal `pry-remote`.  Pry away as normal!
+
+If you are curious to see your integration tests running in a non-headless manner, run your test this way:
+
+```
+$ CAPYBARA_DEBUG=1 bundle exec rspec <path to file>/<file>s
+```
+
 ## Managing your installation
 There are a few things that you will need to do in the TestTrack application:
 * Create `App`s -- client applications that will manage splits on your TestTrack server

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
-ENV['CAPYBARA_DRIVER'] ||= ENV['CI'] ? 'selenium_remote_chrome' : 'selenium_chrome_headless'
+ENV['CAPYBARA_DRIVER'] ||= 'better_cuprite'
 ENV['DATADOG_ENABLED'] = '1'
 
 require File.expand_path('../config/environment', __dir__)

--- a/spec/system/admin_split_decision_create_spec.rb
+++ b/spec/system/admin_split_decision_create_spec.rb
@@ -30,10 +30,11 @@ RSpec.describe 'split decision flow' do
     split_page.decide_split.click
     expect(split_decision_page).to be_loaded
 
-    split_decision_page.create_form.tap do |form|
-      form.variant_options.select 'touch_this'
-      form.submit_button.click
-      accept_alert(/You are deciding/)
+    accept_alert(/You are deciding/) do
+      split_decision_page.create_form.tap do |form|
+        form.variant_options.select 'touch_this'
+        form.submit_button.click
+      end
     end
 
     expect(split_page).to be_loaded

--- a/vendor/gems/ruby_spec_helpers/ruby_spec_helpers.gemspec
+++ b/vendor/gems/ruby_spec_helpers/ruby_spec_helpers.gemspec
@@ -15,10 +15,11 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*", "README.md"]
 
   s.add_dependency 'capybara'
+  s.add_dependency 'cuprite'
+  s.add_dependency 'rspec_junit_formatter'
   s.add_dependency 'rspec-collection_matchers'
   s.add_dependency 'rspec-rails'
   s.add_dependency 'rspec-retry', '~> 0.4.5'
-  s.add_dependency 'rspec_junit_formatter'
   s.add_dependency 'selenium-webdriver'
   s.add_dependency 'site_prism'
   s.add_dependency 'webmock'


### PR DESCRIPTION
### Summary
- Replace selenium-webdriver with cuprite.
- Upgrade [primer_view_components](https://github.com/primer/view_components) up to a version that fixes JS errors detected in system tests.
- Remove chromedriver from ci.yml (no needed anymore!).

/task https://app.asana.com/0/1205654148374805/1205654148376945/f
/domain @Betterment/test_track_core 
