### PR TITLE
Add Optional Environment Banner

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -10,6 +10,7 @@ $app_width: $container-xl;
 @import "typography/base";
 @import "typography/utilities";
 
+@import "components/banner";
 @import "components/flash";
 @import "components/tables";
 @import "components/inputs";

--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,0 +1,16 @@
+.banner {
+  background-color: #ff6759;
+  height: 22px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.banner-text {
+  color: white;
+  font-size: 13px;
+  text-transform: uppercase;
+  font-weight: 500;
+  margin-bottom: 0;
+}

--- a/app/helpers/application_layout_helper.rb
+++ b/app/helpers/application_layout_helper.rb
@@ -3,6 +3,10 @@ module ApplicationLayoutHelper
     content_for(:page_title) || 'Test Track Admin'
   end
 
+  def deployment_env_label
+    ENV.fetch('DEPLOYMENT_ENV_LABEL', nil)
+  end
+
   def site_layout_header_classes
     classes = ['Header']
     classes << "color-bg-accent-emphasis"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,11 @@
 </head>
 
 <body class="<%= site_layout_body_css_classes %>">
+  <% if deployment_env_label.present? %>
+    <div class="banner">
+      <p class="banner-text"><%= deployment_env_label %></p>
+    </div>
+  <% end %>
   <div class="<%= site_layout_header_classes %>">
     <% if content_for?(:header) %>
       <%= yield(:header) %>

--- a/spec/helpers/application_layout_helper_spec.rb
+++ b/spec/helpers/application_layout_helper_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe ApplicationLayoutHelper do
     end
   end
 
+  describe '#deployment_env_label' do
+    it 'returns the value of the DEPLOYMENT_ENV_LABEL environment variable' do
+      with_env DEPLOYMENT_ENV_LABEL: 'stage' do
+        expect(helper.deployment_env_label).to eq 'stage'
+      end
+    end
+
+    it 'returns nil when no DEPLOYMENT_ENV_LABEL environment variable is set' do
+      expect(helper.deployment_env_label).to be_nil
+    end
+  end
+
   describe '#header_modifier' do
     context 'when the header_modifier content_for has been provided' do
       before do

--- a/spec/requests/admin/split_details_spec.rb
+++ b/spec/requests/admin/split_details_spec.rb
@@ -7,17 +7,19 @@ RSpec.describe Admin::SplitsController do
     let(:default_app) { FactoryBot.create(:app, name: "default_app", auth_secret: "6Sd6T7T6Q8hKcoo0t8CTzV0IdN1EEHqXB2Ig4raZsOf") }
     let(:admin) { FactoryBot.create(:admin) }
     let(:deployment_env_label) { 'Stage Environment' }
+    let(:banner_tag) { "<p class=\"banner-text\">" }
 
     before do
       login_as admin
     end
 
     context 'when no DEPLOYMENT_ENV_LABEL is set' do
-      it 'renders without banner' do
+      it 'renders without environment label banner' do
         get '/admin'
 
         expect(response).to have_http_status :ok
 
+        expect(response.body).not_to include(banner_tag)
         expect(response.body).not_to include(deployment_env_label)
       end
     end
@@ -29,11 +31,12 @@ RSpec.describe Admin::SplitsController do
         end
       end
 
-      it 'renders with banner' do
+      it 'renders with environment label banner' do
         get '/admin'
 
         expect(response).to have_http_status :ok
 
+        expect(response.body).to include(banner_tag)
         expect(response.body).to include(deployment_env_label)
       end
     end

--- a/spec/requests/admin/split_details_spec.rb
+++ b/spec/requests/admin/split_details_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SplitsController do
+  include Warden::Test::Helpers
+
+  describe 'GET /admin' do
+    let(:default_app) { FactoryBot.create(:app, name: "default_app", auth_secret: "6Sd6T7T6Q8hKcoo0t8CTzV0IdN1EEHqXB2Ig4raZsOf") }
+    let(:admin) { FactoryBot.create(:admin) }
+    let(:deployment_env_label) { 'Stage Environment' }
+
+    before do
+      login_as admin
+    end
+
+    context 'when no DEPLOYMENT_ENV_LABEL is set' do
+      it 'renders without banner' do
+        get '/admin'
+
+        expect(response).to have_http_status :ok
+
+        expect(response.body).not_to include(deployment_env_label)
+      end
+    end
+
+    context 'when DEPLOYMENT_ENV_LABEL is set' do
+      around do |example|
+        with_env DEPLOYMENT_ENV_LABEL: deployment_env_label do
+          example.run
+        end
+      end
+
+      it 'renders with banner' do
+        get '/admin'
+
+        expect(response).to have_http_status :ok
+
+        expect(response.body).to include(deployment_env_label)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/split_details_spec.rb
+++ b/spec/requests/admin/split_details_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Admin::SplitsController do
   include Warden::Test::Helpers
 
   describe 'GET /admin' do
-    let(:default_app) { FactoryBot.create(:app, name: "default_app", auth_secret: "6Sd6T7T6Q8hKcoo0t8CTzV0IdN1EEHqXB2Ig4raZsOf") }
     let(:admin) { FactoryBot.create(:admin) }
     let(:deployment_env_label) { 'Stage Environment' }
     let(:banner_tag) { "<p class=\"banner-text\">" }


### PR DESCRIPTION
### Summary

Currently, if an organization uses Test Track for multiple environments (e.g. production and stage), it can be a bit difficult to discern at first glance for which environment a user is managing a given split test.

This proposed change gives users the option to set a `DEPLOYMENT_ENV_LABEL` variable in the `.env` or `.env.local` file, which will subsequently be rendered in a bright red banner, like so:

![Screenshot 2024-03-20 at 5 23 52 PM](https://github.com/Betterment/test_track/assets/67171899/f273fb03-dd86-433d-bd7b-77268bf27ae5)


The banner is intentionally a tad obnoxious to make it glaringly obvious to the user which environment they are in. 

When no `DEPLOYMENT_ENV_LABEL` variable is set, the header renders as usual:

![Screenshot 2024-03-20 at 5 23 24 PM](https://github.com/Betterment/test_track/assets/67171899/fc01c995-b5d0-40ac-ac97-1421a725c449)


I envision organizations using the existing state for production and the banner state for a non-production environment (or perhaps vice-versa). 

/domain @Betterment/test_track_core 
