### PR TITLE
drop 3.0 from GH matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.0', '3.1', '3.2']
+        ruby: ['3.1', '3.2']
     services:
       postgres:
         image: postgres:11.0


### PR DESCRIPTION
This is blocking the omniauth-saml security patch (https://github.com/Betterment/test_track/pull/223; see action run: https://github.com/Betterment/test_track/actions/runs/10819720832/job/30018225320?pr=223). We're on Rails 7, so we don't need to worry about https://github.com/Betterment/test_track/pull/187/files#r1150893892

I'm skipping bumping `rubocop.yml`'s `TargetRubyVersion` in the interest of time.

### Summary

> Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together.

### Other Information

> If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

> Thanks for contributing to TestTrack!

/domain @Betterment/test_track_core 
/platform @smudge 
