### PR TITLE
add a `bin/webpack`

### DIFF
--- a/bin/webpack
+++ b/bin/webpack
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+yarn build:css


### PR DESCRIPTION
### Summary
see: https://github.com/Betterment/test-track-app/pull/31#discussion_r1757654499

In CI we have a frontend build verification step which runs either `bin/vite` or `bin/webpack`, but `test_track` uses none of those. As a workaround, this commit adds a `bin/webpack` script that just runs `yarn build:css` internally.

### Other Information

> If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

> Thanks for contributing to TestTrack!

/domain @Betterment/test_track_core 
