### PR TITLE
fix: ensure individually_overridden is reliably cleared

### DIFF
--- a/app/models/arbitrary_assignment_creation.rb
+++ b/app/models/arbitrary_assignment_creation.rb
@@ -73,7 +73,7 @@ class ArbitraryAssignmentCreation
   end
 
   def individual_override?
-    superseding? && (assignment.individually_overridden || !bulk_assignment?)
+    superseding? && !bulk_assignment?
   end
 
   def bulk_assignment?

--- a/app/models/bulk_reassignment.rb
+++ b/app/models/bulk_reassignment.rb
@@ -65,6 +65,7 @@ class BulkReassignment
         mixpanel_result = NULL,
         bulk_assignment_id = #{connection.quote(bulk_assignment.id)},
         visitor_supersession_id = NULL,
+        individually_overridden = false,
         context = 'bulk_assignment',
         force = #{connection.quote(bulk_assignment.force)}
       WHERE id #{assignment_id_clause}

--- a/db/migrate/20260504164518_clear_stale_individually_overridden_flags.rb
+++ b/db/migrate/20260504164518_clear_stale_individually_overridden_flags.rb
@@ -1,0 +1,14 @@
+class ClearStaleIndividuallyOverriddenFlags < ActiveRecord::Migration[7.2]
+  def up
+    execute <<~SQL
+      UPDATE assignments
+      SET individually_overridden = false
+      WHERE individually_overridden = true
+        AND context IS DISTINCT FROM 'individually_overridden'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2019_04_13_210327) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_04_164518) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"

--- a/spec/models/arbitrary_assignment_creation_spec.rb
+++ b/spec/models/arbitrary_assignment_creation_spec.rb
@@ -233,15 +233,15 @@ RSpec.describe ArbitraryAssignmentCreation do
         end
       end
 
-      it "remains during a bulk assignment" do
+      it "is cleared during a bulk assignment" do
         existing_assignment = FactoryBot.create(:assignment, existing_assignment_params.merge(individually_overridden: true))
         bulk_assignment = FactoryBot.create(:bulk_assignment, split: existing_assignment_params[:split])
 
         ArbitraryAssignmentCreation.create!(params.merge(bulk_assignment_id: bulk_assignment.id))
 
         expect(existing_assignment.reload.bulk_assignment).to eq bulk_assignment
-        expect(existing_assignment).to be_individually_overridden
-        expect(existing_assignment.context).to eq "individually_overridden"
+        expect(existing_assignment).not_to be_individually_overridden
+        expect(existing_assignment.context).to eq "bulk_assignment"
       end
 
       it "makes a previous bulk_assignment nil" do

--- a/spec/models/bulk_assignment_creation_spec.rb
+++ b/spec/models/bulk_assignment_creation_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe BulkAssignmentCreation do
       expect(previous_assignment.individually_overridden).to be false
     end
 
-    it "maintains the individually_overridden dirty flag across bulk assignments" do
+    it "clears the individually_overridden flag across bulk assignments" do
       assignment.update(individually_overridden: true, context: "individually_overridden")
 
       subject.save
@@ -297,7 +297,7 @@ RSpec.describe BulkAssignmentCreation do
       current_assignment = Assignment.find_by(visitor:)
       previous_assignment = current_assignment.previous_assignments.first
 
-      expect(current_assignment.individually_overridden).to be true
+      expect(current_assignment.individually_overridden).to be false
       expect(current_assignment.context).to eq "bulk_assignment"
       expect(previous_assignment.individually_overridden).to be true
       expect(previous_assignment.context).to eq "individually_overridden"

--- a/spec/models/bulk_reassignment_spec.rb
+++ b/spec/models/bulk_reassignment_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe BulkReassignment do
       expect(assignment.mixpanel_result).to be_nil
     end
 
-    it "preserves individually_overridden" do
-      expect(assignment.individually_overridden).to be true
+    it "clears individually_overridden" do
+      expect(assignment.individually_overridden).to be false
     end
 
     it "uses bulk_assignment's created_at as updated_at" do


### PR DESCRIPTION
individually_overridden was not being maintained as a trustworthy signal for "this assignment is currently a manual per-visitor override." Two related bugs caused it to persist stale true values after bulk operations:

1. BulkReassignment's SQL UPDATE never included individually_overridden in its SET clause, leaving the flag true after bulk reassignment.

2. ArbitraryAssignmentCreation#individual_override? had a stickiness term (assignment.individually_overridden || !bulk_assignment?) that carried the flag forward onto the result even when a bulk operation superseded an individually-overridden record via the ArbitraryAssignmentCreation path. With the BulkReassignment bug fixed, this stickiness has no legitimate purpose — the flag will now be correctly false on any record a bulk operation has touched, so the term simplifies to !bulk_assignment?.

A backfill migration corrects existing records where individually_overridden is true but context shows the last operation was not an individual override. The history of individual overrides is preserved in previous_assignments, though those records may themselves be tainted by these bugs.

@samandmoore this is some prework buggy data identified before I take a stab at making stale individual overrides time out.

@jonmauney is there any possible impact on downstream processing? I don't think this value (which had to my eye buggy values after some bulk operations) is exposed on any API or used in filtering, and I believe all A/B test analysis is performed based on client-generated events now, so this feels low risk, but let me know if anything feels like it might be depending on this!